### PR TITLE
(fix) Re-enable EntityProxy as value for entity property

### DIFF
--- a/followthemoney/value.py
+++ b/followthemoney/value.py
@@ -48,6 +48,11 @@ def string_list(value: Any, sanitize: bool = False) -> List[str]:
     if isinstance(value, Mapping):
         text = value.get("id")
         return [text] if text is not None else []
+    # EntityProxy
+    try:
+        return [value.id]
+    except AttributeError:
+        pass
     if isinstance(value, Sequence):
         stexts: List[str] = []
         for inner in value:
@@ -59,7 +64,4 @@ def string_list(value: Any, sanitize: bool = False) -> List[str]:
         if text is None:
             return []
         return [text]
-    # EntityProxy
-    if hasattr(value, "id") and value.id:
-        return [value.id]
     raise TypeError("Cannot convert %r to string list" % value)

--- a/followthemoney/value.py
+++ b/followthemoney/value.py
@@ -50,7 +50,7 @@ def string_list(value: Any, sanitize: bool = False) -> List[str]:
         return [text] if text is not None else []
     # EntityProxy
     try:
-        return [value.id]
+        return string_list(value.id, sanitize=sanitize)
     except AttributeError:
         pass
     if isinstance(value, Sequence):

--- a/followthemoney/value.py
+++ b/followthemoney/value.py
@@ -1,17 +1,22 @@
 from typing import Any, List, Mapping, Sequence, Set, Union
 from datetime import datetime, date, timezone
+import typing
 from prefixdate import DatePrefix
 
 from followthemoney.util import sanitize_text
 
-Value = Union[str, int, float, bool, date, datetime, DatePrefix, None]
+if typing.TYPE_CHECKING:
+    from followthemoney.proxy import E
+
+Value = Union[str, int, float, bool, date, datetime, DatePrefix, None, "E"]
 Values = Union[Value, Sequence[Value], Set[Value]]
 
 
 def string_list(value: Any, sanitize: bool = False) -> List[str]:
     """Convert a value - which may be a list or set - to a list of strings."""
-    # This function is called in the inner loop of placing values into entities, so it's unrolled to
-    # avoid the overhead of a comparatively heavy ops like `isinstance`.
+    # This function is called in the inner loop of placing values into entities,
+    # so it's unrolled to avoid the overhead of a comparatively heavy ops like
+    # `isinstance`.
     if value is None:
         return []
     type_ = type(value)
@@ -54,4 +59,7 @@ def string_list(value: Any, sanitize: bool = False) -> List[str]:
         if text is None:
             return []
         return [text]
+    # EntityProxy
+    if hasattr(value, "id") and value.id:
+        return [value.id]
     raise TypeError("Cannot convert %r to string list" % value)

--- a/followthemoney/value.py
+++ b/followthemoney/value.py
@@ -25,7 +25,7 @@ def string_list(value: Any, sanitize: bool = False) -> List[str]:
             value = sanitize_text(value)
             if value is None:
                 return []
-        return [value]
+        return [value] if len(value) > 0 else []
     if type_ is int:
         return [str(value)]
     if type_ is float:
@@ -53,15 +53,15 @@ def string_list(value: Any, sanitize: bool = False) -> List[str]:
     # Entity dict
     if isinstance(value, Mapping):
         return string_list(value.get("id"), sanitize=sanitize)
+    if isinstance(value, (str, bytes)):
+        # Handle sub-classes of str, bytes - always sanitize
+        text = sanitize_text(value)
+        if text is None:
+            return []
+        return [text]
     if isinstance(value, Sequence):
         stexts: List[str] = []
         for inner in value:
             stexts.extend(string_list(inner, sanitize=sanitize))
         return stexts
-    if isinstance(value, (str, bytes)):
-        # Handle sub-classes of str
-        text = sanitize_text(value)
-        if text is None:
-            return []
-        return [text]
     raise TypeError("Cannot convert %r to string list" % value)

--- a/followthemoney/value.py
+++ b/followthemoney/value.py
@@ -6,9 +6,9 @@ from prefixdate import DatePrefix
 from followthemoney.util import sanitize_text
 
 if typing.TYPE_CHECKING:
-    from followthemoney.proxy import E
+    from followthemoney.proxy import EntityProxy
 
-Value = Union[str, int, float, bool, date, datetime, DatePrefix, None, "E"]
+Value = Union[str, int, float, bool, date, datetime, DatePrefix, None, "EntityProxy"]
 Values = Union[Value, Sequence[Value], Set[Value]]
 
 
@@ -45,14 +45,14 @@ def string_list(value: Any, sanitize: bool = False) -> List[str]:
         return texts
     if isinstance(value, DatePrefix):
         return [value.text] if value.text else []
-    if isinstance(value, Mapping):
-        text = value.get("id")
-        return [text] if text is not None else []
     # EntityProxy
     try:
         return string_list(value.id, sanitize=sanitize)
     except AttributeError:
         pass
+    # Entity dict
+    if isinstance(value, Mapping):
+        return string_list(value.get("id"), sanitize=sanitize)
     if isinstance(value, Sequence):
         stexts: List[str] = []
         for inner in value:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -390,3 +390,13 @@ def test_value_deduplication_cleaned():
         cleaned=True,
     )
     assert proxy.get("name") == ["ACME, Inc."]
+
+
+def test_value_entity_add():
+    proxy = EntityProxy.from_dict({
+        "id": "rel",
+        "schema": "Directorship",
+        "properties": {}
+    })
+    proxy.add("director", ENTITY)
+    assert proxy.get("director") == ["test"]

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -1,0 +1,25 @@
+from followthemoney.value import string_list
+from followthemoney import model
+from followthemoney.proxy import EntityProxy
+
+
+def test_string_list():
+    assert string_list("test") == ["test"]
+    assert string_list("") == []
+    assert string_list(b"test") == ["test"]
+    assert string_list(123) == ["123"]
+    assert string_list(45.67) == ["45.67"]
+    assert string_list(True) == ["true"]
+    assert string_list(False) == ["false"]
+    assert string_list(None) == []
+    assert string_list(["a", "b", "c"]) == ["a", "b", "c"]
+    assert string_list(["", "b", "c"]) == ["b", "c"]
+    assert string_list({"id": "entity1"}) == ["entity1"]
+    assert string_list({"id": None}) == []
+    assert string_list({"name": "entity2"}) == []
+    schema = model.get("Person")
+    assert schema is not None
+    proxy = EntityProxy(schema, {})
+    assert string_list(proxy) == []
+    proxy.id = "entity3"
+    assert string_list(proxy) == ["entity3"]


### PR DESCRIPTION
Hey, I noticed a bug in the new `string_list` function that is invoked for adding properties to `EntityProxy`.

Aleph and probably many other (legacy?) entity data generation pipelines are adding "full" entities to a prop that is entity type instead of only the ID. This breaks the new `string_list`.

I though about that it could be enforced for ftm4 to only allow this behaviour, but a lot of code (e.g. in `ingest-file` ) is doing `EntityProxy.add("director", other_entity)` and maybe for backwards compatibility this should remain possible, as added in this fix.

Open to discuss this, though :)