### PR TITLE
Add Chinese Unified Social Credit Identifier

### DIFF
--- a/followthemoney/schema/LegalEntity.yaml
+++ b/followthemoney/schema/LegalEntity.yaml
@@ -102,6 +102,12 @@ LegalEntity:
     bvdId:
       label: Bureau van Dijk ID
       type: identifier
+    uscCode:
+      # cf. https://en.wikipedia.org/wiki/Unified_Social_Credit_Identifier
+      label: "USCC"
+      description: "Unified Social Credit Identifier"
+      type: identifier
+      format: uscc
     icijId:
       label: ICIJ ID
       description: "ID according to International Consortium for Investigative Journalists"

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -4009,6 +4009,16 @@
           "qname": "LegalEntity:uniqueEntityId",
           "type": "identifier"
         },
+        "uscCode": {
+          "description": "Unified Social Credit Identifier",
+          "format": "uscc",
+          "label": "USCC",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "uscCode",
+          "qname": "LegalEntity:uscCode",
+          "type": "identifier"
+        },
         "userAccounts": {
           "label": "User accounts",
           "matchable": true,

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -4009,6 +4009,16 @@
           "qname": "LegalEntity:uniqueEntityId",
           "type": "identifier"
         },
+        "uscCode": {
+          "description": "Unified Social Credit Identifier",
+          "format": "uscc",
+          "label": "USCC",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "uscCode",
+          "qname": "LegalEntity:uscCode",
+          "type": "identifier"
+        },
         "userAccounts": {
           "label": "User accounts",
           "matchable": true,


### PR DESCRIPTION
Applies to `LegalEntity`, the relevant format was introduced in `rigour` 0.14.