### PR TITLE
Use pydantic models for catalog / dataset metadata

### DIFF
--- a/followthemoney/dataset/coverage.py
+++ b/followthemoney/dataset/coverage.py
@@ -1,13 +1,11 @@
 from typing import List, Literal, Optional, TypeAlias
+from pydantic import BaseModel
 
-from pydantic import field_validator
-
-from followthemoney.dataset.util import PartialDate, SerializableModel, type_require
-from followthemoney.types import registry
+from followthemoney.dataset.util import CountryCode, PartialDate
 
 
 # Derived from Aleph
-FREQUENCIES: TypeAlias = Literal[
+FREQUENCY_TYPE: TypeAlias = Literal[
     "unknown",
     "never",
     "hourly",
@@ -18,19 +16,14 @@ FREQUENCIES: TypeAlias = Literal[
 ]
 
 
-class DataCoverage(SerializableModel):
+class DataCoverage(BaseModel):
     """Details on the temporal and geographic scope of a dataset."""
 
     start: Optional[PartialDate] = None
     end: Optional[PartialDate] = None
-    countries: List[str] = []
-    frequency: FREQUENCIES = "unknown"
+    countries: List[CountryCode] = []
+    frequency: FREQUENCY_TYPE = "unknown"
     schedule: Optional[str] = None
-
-    @field_validator("countries", mode="after")
-    @classmethod
-    def ensure_countries(cls, value: List[str]) -> List[str]:
-        return [type_require(registry.country, c) for c in value]
 
     def __repr__(self) -> str:
         return f"<DataCoverage({self.start!r}, {self.end!r}, {self.countries!r})>"

--- a/followthemoney/dataset/publisher.py
+++ b/followthemoney/dataset/publisher.py
@@ -1,12 +1,12 @@
 from typing import Optional
 
-from pydantic import HttpUrl, field_validator
+from pydantic import BaseModel, HttpUrl
 
-from followthemoney.dataset.util import SerializableModel, type_require
+from followthemoney.dataset.util import CountryCode
 from followthemoney.types import registry
 
 
-class DataPublisher(SerializableModel):
+class DataPublisher(BaseModel):
     """Publisher information, eg. the government authority."""
 
     name: str
@@ -14,14 +14,9 @@ class DataPublisher(SerializableModel):
     name_en: Optional[str] = None
     acronym: Optional[str] = None
     description: Optional[str] = None
-    country: Optional[str] = None
+    country: Optional[CountryCode] = None
     official: Optional[bool] = False
     logo_url: Optional[HttpUrl] = None
-
-    @field_validator("country", mode="after")
-    @classmethod
-    def ensure_country(cls, value: str) -> str:
-        return type_require(registry.country, value)
 
     @property
     def country_label(self) -> Optional[str]:

--- a/followthemoney/dataset/publisher.py
+++ b/followthemoney/dataset/publisher.py
@@ -1,41 +1,30 @@
-from banal import as_bool
-from typing import Optional, Dict, Any
+from typing import Optional
 
+from pydantic import HttpUrl, field_validator
+
+from followthemoney.dataset.util import SerializableModel, type_require
 from followthemoney.types import registry
-from followthemoney.dataset.util import Named, cleanup
-from followthemoney.dataset.util import type_check, type_require
 
 
-class DataPublisher(Named):
+class DataPublisher(SerializableModel):
     """Publisher information, eg. the government authority."""
 
-    def __init__(self, data: Dict[str, Any]):
-        name = type_require(registry.string, data.get("name"))
-        super().__init__(name)
-        self.url = type_require(registry.url, data.get("url"))
-        self.name_en = type_check(registry.string, data.get("name_en"))
-        self.acronym = type_check(registry.string, data.get("acronym"))
-        self.description = type_check(registry.string, data.get("description"))
-        self.country = type_check(registry.country, data.get("country"))
-        self.official = as_bool(data.get("official", False))
-        self.logo_url = type_check(registry.url, data.get("logo_url"))
+    name: str
+    url: Optional[HttpUrl] = None
+    name_en: Optional[str] = None
+    acronym: Optional[str] = None
+    description: Optional[str] = None
+    country: Optional[str] = None
+    official: Optional[bool] = False
+    logo_url: Optional[HttpUrl] = None
+
+    @field_validator("country", mode="after")
+    @classmethod
+    def ensure_country(cls, value: str) -> str:
+        return type_require(registry.country, value)
 
     @property
     def country_label(self) -> Optional[str]:
         if self.country is None:
             return None
         return registry.country.caption(self.country)
-
-    def to_dict(self) -> Dict[str, Any]:
-        data = {
-            "name": self.name,
-            "name_en": self.name_en,
-            "acronym": self.acronym,
-            "url": self.url,
-            "description": self.description,
-            "country": self.country,
-            "country_label": self.country_label,
-            "official": self.official,
-            "logo_url": self.logo_url,
-        }
-        return cleanup(data)

--- a/followthemoney/dataset/resource.py
+++ b/followthemoney/dataset/resource.py
@@ -1,38 +1,30 @@
-from typing import Optional, Dict, Any
+from datetime import datetime
+from typing import Optional
 
+from pydantic import BaseModel, HttpUrl, field_validator
+
+from followthemoney.dataset.util import type_check
 from followthemoney.types import registry
-from followthemoney.dataset.util import Named, cleanup
-from followthemoney.dataset.util import type_check, type_require
 
 
-class DataResource(Named):
+class DataResource(BaseModel):
     """A downloadable resource that is part of a dataset."""
 
-    def __init__(self, data: Dict[str, Any]) -> None:
-        name = type_require(registry.string, data.get("name", data.get("path")))
-        super().__init__(name)
-        self.url = type_require(registry.url, data.get("url"))
-        self.checksum = type_check(registry.checksum, data.get("checksum"))
-        self.timestamp = type_check(registry.date, data.get("timestamp"))
-        self.mime_type = type_check(registry.mimetype, data.get("mime_type"))
-        self.title = type_check(registry.string, data.get("title"))
-        self.size = int(data["size"]) if "size" in data else None
+    name: str
+    url: Optional[HttpUrl] = None
+    checksum: Optional[str] = None
+    timestamp: Optional[datetime] = None
+    mime_type: Optional[str] = None
+    title: Optional[str] = None
+    size: Optional[int] = None
+
+    @field_validator("mime_type", mode="after")
+    @classmethod
+    def ensure_mime_type(cls, value: Optional[str]) -> Optional[str]:
+        return type_check(registry.mimetype, value)
 
     @property
     def mime_type_label(self) -> Optional[str]:
         if self.mime_type is None:
             return None
         return registry.mimetype.caption(self.mime_type)
-
-    def to_dict(self) -> Dict[str, Any]:
-        data = {
-            "name": self.name,
-            "url": self.url,
-            "checksum": self.checksum,
-            "timestamp": self.timestamp,
-            "mime_type": self.mime_type,
-            "mime_type_label": self.mime_type_label,
-            "title": self.title,
-            "size": self.size,
-        }
-        return cleanup(data)

--- a/followthemoney/dataset/resource.py
+++ b/followthemoney/dataset/resource.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from typing import Optional
-
 from pydantic import BaseModel, HttpUrl, field_validator
 
-from followthemoney.dataset.util import type_check
 from followthemoney.types import registry
 
 
@@ -20,8 +18,10 @@ class DataResource(BaseModel):
 
     @field_validator("mime_type", mode="after")
     @classmethod
-    def ensure_mime_type(cls, value: Optional[str]) -> Optional[str]:
-        return type_check(registry.mimetype, value)
+    def ensure_mime_type(cls, value: str) -> Optional[str]:
+        if not registry.mimetype.validate(value):
+            raise ValueError(f"Invalid MIME type: {value!r}")
+        return value
 
     @property
     def mime_type_label(self) -> Optional[str]:

--- a/followthemoney/dataset/util.py
+++ b/followthemoney/dataset/util.py
@@ -1,92 +1,39 @@
-from typing import Annotated, Any, Dict, List, Optional, Type
+from normality import slugify
+from typing import Annotated, Any
+from pydantic import BeforeValidator
 
-from normality import slugify, stringify
-from prefixdate import parse as prefix_parse
-from pydantic import BaseModel, BeforeValidator
-
-from followthemoney.exc import MetadataException
 from followthemoney.types import registry
-from followthemoney.types.common import PropertyType
 
 
-def type_check(type_: PropertyType, value: Any) -> Optional[str]:
-    text = stringify(value)
-    if text is None:
-        return None
-    cleaned = type_.clean_text(text)
-    if cleaned is None:
-        raise MetadataException("Invalid %s: %r" % (type_.name, value))
-    return cleaned
-
-
-def type_require(type_: PropertyType, value: Any) -> str:
-    """Check that the given metadata field is a valid string of the given FtM
-    property type."""
-    text = stringify(value)
-    if text is None:
-        raise MetadataException("Invalid %s: %r" % (type_.name, value))
-    cleaned = type_.clean_text(text)
-    if cleaned is None:
-        raise MetadataException("Invalid %s: %r" % (type_.name, value))
-    return cleaned
-
-
-def datetime_check(value: Any) -> Optional[str]:
-    """Check that the given metadata field is a valid datetime."""
-    return prefix_parse(value).text
-
-
-def int_check(value: Any) -> Optional[int]:
-    """Check that the given metadata field is a valid integer."""
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def dataset_name_check(value: Any) -> str:
+def dataset_name_check(value: str) -> str:
     """Check that the given value is a valid dataset name. This doesn't convert
     or clean invalid names, but raises an error if they are not compliant to
     force the user to fix an invalid name"""
-    cleaned = type_require(registry.string, value)
-    if slugify(cleaned, sep="_") != cleaned:
-        raise MetadataException("Invalid %s: %r" % ("dataset name", value))
+    if slugify(value, sep="_") != value:
+        raise ValueError("Invalid %s: %r" % ("dataset name", value))
+    return value
+
+
+def type_check_date(value: Any) -> str:
+    """Check that the given value is a valid date string."""
+    cleaned = registry.date.clean(value)
+    if cleaned is None:
+        raise ValueError("Invalid date: %r" % value)
     return cleaned
-
-
-def string_list(value: Any) -> List[str]:
-    if value is None:
-        return []
-    return [type_require(registry.string, s) for s in value]
-
-
-def cleanup(data: Dict[str, Any]) -> Dict[str, Any]:
-    for key, value in list(data.items()):
-        if value is None:
-            data.pop(key)
-    return data
-
-
-def type_check_date(value: Any) -> Optional[str]:
-    return type_check(registry.date, value)
 
 
 PartialDate = Annotated[str, BeforeValidator(type_check_date)]
 
 
-class SerializableModel(BaseModel):
-    def to_dict(self) -> Dict[str, Any]:
-        data = self.model_dump(mode="json")
-        return cleanup(data)
+def type_check_country(value: Any) -> str:
+    """Check that the given value is a valid country code."""
+    cleaned = registry.country.clean(value)
+    if cleaned is None:
+        raise ValueError("Invalid country code: %r" % value)
+    return cleaned
 
 
-class OperationalBase:
-
-    Model: Type[SerializableModel]
-    model: SerializableModel
-
-    def to_dict(self) -> Dict[str, Any]:
-        return self.model.to_dict()
+CountryCode = Annotated[str, BeforeValidator(type_check_country)]
 
 
 class Named:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "networkx >= 2.5, < 3.5",
     "openpyxl >= 3.0.5, < 4.0.0",
     "orjson >= 3.7, < 4.0",
+    "pydantic (>=2.11.7,<3.0.0)",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes #40 

Not sure if this is the best way to do it, happy to refine

`Dataset` and `DataCatalog` can receive an optional extra `model` argument during initialization that defaults to `CatalogModel` and `DatasetModel`. This is used to provide a `.model` property that holds the pydantic model for the specified class.

The other smaller metadata models (`Resource`, `Publisher`, `Coverage`) are just ported to pydantic straightforward