### PR TITLE
Fix handling of None entity.id in EntityProxy and Namespace

### DIFF
--- a/followthemoney/namespace.py
+++ b/followthemoney/namespace.py
@@ -26,9 +26,9 @@ the server without compromising isolation.
 import hmac
 from typing import Any, Optional, Tuple, Union
 
-from followthemoney.types import registry
 from followthemoney.proxy import E
-from followthemoney.util import key_bytes, get_entity_id
+from followthemoney.types import registry
+from followthemoney.util import get_entity_id, key_bytes
 
 
 class Namespace(object):
@@ -69,7 +69,7 @@ class Namespace(object):
         digest.update(key_bytes(entity_id))
         return digest.hexdigest()
 
-    def sign(self, entity_id: Union[str, None]) -> Optional[str]:
+    def sign(self, entity_id: Optional[str]) -> Optional[str]:
         """Apply a namespace signature to an entity ID, removing any
         previous namespace marker."""
         if entity_id is None:

--- a/followthemoney/namespace.py
+++ b/followthemoney/namespace.py
@@ -69,9 +69,11 @@ class Namespace(object):
         digest.update(key_bytes(entity_id))
         return digest.hexdigest()
 
-    def sign(self, entity_id: str) -> Optional[str]:
+    def sign(self, entity_id: Union[str, None]) -> Optional[str]:
         """Apply a namespace signature to an entity ID, removing any
         previous namespace marker."""
+        if entity_id is None:
+            return None
         parsed_id, _ = self.parse(entity_id)
         if not len(self.bname):
             return parsed_id

--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -57,7 +57,7 @@ class EntityProxy(object):
         #: A unique identifier for this entity, usually a hashed natural key,
         #: a UUID, or a very simple slug. Can be signed using a
         #: :class:`~followthemoney.namespace.Namespace`.
-        self.id = str(data["id"]) if "id" in data else None
+        self.id = str(data["id"]) if data.get("id") else None
         if not cleaned:
             self.id = sanitize_text(self.id)
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -46,3 +46,15 @@ def test_apply():
     out = ns.apply(proxy)
     assert out.id == ns.sign(proxy.id), out
     # assert proxy.id in out.get('sameAs'), out
+
+    # no id
+    entity = {
+        "schema": "LegalEntity",
+        "properties": {"sameAs": ["kumkwat"], "parent": ["pretzel"]},
+    }
+    proxy = model.get_proxy(entity)
+    assert proxy.id is None, proxy.id
+    ns = Namespace("fruit")
+    out = ns.apply(proxy)
+    assert ns.sign(None) is None
+    assert out.id is None


### PR DESCRIPTION
This catches a regression found in OpenAleph, as we are using namespacing a lot over there ;)

Due to this call, https://github.com/opensanctions/followthemoney/blob/main/followthemoney/proxy.py#L60 an empty (`None`) entity id would be converted into a string `"None"`. This happens when the entity is cloned in calling `ns.sign(entity)` in the namespace module. As entity IDs _could_ be empty or `None` (as seen in OpenAleph tests here: https://github.com/openaleph/openaleph/blob/main/aleph/tests/test_collections_api.py#L196), this should be taken into account.

Of course, higher application logic should catch an empty Entity ID somewhere earlier, though :)