### PR TITLE
Add origin to StatementEntity context

### DIFF
--- a/followthemoney/statement/entity.py
+++ b/followthemoney/statement/entity.py
@@ -29,6 +29,7 @@ class StatementEntity(EntityProxy):
         "extra_referents",
         "dataset",
         "last_change",
+        "origin",
         "_statements",
     )
 
@@ -372,6 +373,7 @@ class StatementEntity(EntityProxy):
         }
         referents: Set[Optional[str]] = set(self.extra_referents)
         datasets = set(self.datasets)
+        origins: Set[str] = set()
         first_seen = None
         last_seen = None
         for stmts in self._statements.values():
@@ -385,9 +387,13 @@ class StatementEntity(EntityProxy):
                 if stmt.entity_id is not None and stmt.entity_id != self.id:
                     referents.add(stmt.entity_id)
                 datasets.add(stmt.dataset)
+                if stmt.origin is not None:
+                    origins.add(stmt.origin)
 
         data["referents"] = list(referents)
         data["datasets"] = list(datasets)
+        if origins:
+            data["origin"] = list(origins)
 
         if first_seen is not None:
             data["first_seen"] = first_seen

--- a/tests/statement/test_entity.py
+++ b/tests/statement/test_entity.py
@@ -227,3 +227,15 @@ def test_statement_dict():
     assert sp2.last_change == sp.last_change
     assert sp2.get("name") == sp.get("name")
     assert sp2.get("birthDate") == sp.get("birthDate")
+
+
+def test_entity_origin():
+    dx = Dataset.make({"name": "test", "title": "Test"})
+    sp = StatementEntity.from_data(dx, EXAMPLE)
+    data = sp.to_dict()
+    assert "origin" not in data
+    stmt = next(sp.statements)
+    stmt.origin = "space"
+    sp.add_statement(stmt)
+    data = sp.to_dict()
+    assert data["origin"] == ["space"]


### PR DESCRIPTION
As statements have an `origin` property, it would be great to have that exposed in the context dict (`StatementEntity.to_dict()`)

This then would become part of the `context` property of `EntityProxy` which is known by e.g. _OpenAleph_ ;)