### PR TITLE
Better descriptions for some classifiers/identifier on companies

### DIFF
--- a/followthemoney/schema/Company.yaml
+++ b/followthemoney/schema/Company.yaml
@@ -58,20 +58,20 @@ Company:
       type: identifier
     caemCode:
       label: "COD CAEM"
-      description: "(RO) What kind of activity a legal entity is allowed to develop"
+      description: "Romanian classifier used to identify the types of economic activities that a business can provide in Romania"
       matchable: false
     kppCode:
       label: "KPP"
-      description: "(RU, КПП) in addition to INN for orgs; reason for registration at FNS"
+      description: "Russian code issued by the tax authority, identifies the reason for registration at the Federal Tax Service (Russian: КПП). A company may have multiple KPP codes (e.g. for different branches), and the codes are not unique across companies."
       type: identifier
       matchable: false
     okvedCode:
       label: "OKVED(2) Classifier"
-      description: "(RU, ОКВЭД) Economical activity classifier. OKVED2 is the same but newer"
+      description: "Russian classifier that that categorizes businesses by their (primary and secondary) economic activities (Russian: ОКВЭД)"
       matchable: false
     okopfCode:
       label: "OKOPF"
-      description: "(RU, ОКОПФ) What kind of business entity"
+      description: "Russian classifier that that categorizes different types of legal entities in Russia based on their organizational and legal structure (Russian: ОКОПФ)"
       matchable: false
     fnsCode:
       label: "Federal tax service code"

--- a/followthemoney/schema/LegalEntity.yaml
+++ b/followthemoney/schema/LegalEntity.yaml
@@ -74,7 +74,7 @@ LegalEntity:
     idNumber:
       label: ID Number
       type: identifier
-      description: "ID number of any applicable ID"
+      description: "ID number of any applicable personal identification document. Should be used for people only — for companies, prefer the `registrationNumber` property"
     taxNumber:
       label: Tax Number
       type: identifier
@@ -118,13 +118,13 @@ LegalEntity:
       matchable: false
     innCode:
       label: "INN"
-      description: "Russian company ID"
+      description: "Russian tax identification number (Russian: ИНН). Issued to businesses and individuals in Russia"
       type: identifier
       format: inn
       maxLength: 32
     ogrnCode:
       label: "OGRN"
-      description: "Major State Registration Number"
+      description: "Identification number used in Russia's Unified State Register of Legal Entities (EGRUL) (Russian: ОГРН)"
       type: identifier
       format: ogrn
       maxLength: 32
@@ -148,7 +148,7 @@ LegalEntity:
       maxLength: 32
     npiCode:
       label: "NPI"
-      description: "National Provider Identifier"
+      description: "National Provider Identifier, issued to health care providers in the United States"
       type: identifier
       format: npi
       maxLength: 16


### PR DESCRIPTION
- **Add `proof` to Interval**
- **Bump vite from 6.2.5 to 6.2.6 in /docs (#1726)**
- **Tenge gonna teng, refs #986.**
- **Simplify unit tests according to pytest style**
- **more test simplification**
- **Straight port from nomenklatura**
- **Try to make older Pythons typecheck this**
- **Simplify and improve coverage a bit**
- **Make title == name if title is unset**
- **Make title optional for datasets**
- **Remove weird reference to zavod/programs**
- **Adopt statement data model and update imports**
- **Bring in some CLI commands**
- **Fix some weird breakage**
- **Clean up imports**
- **Remove dependency on `fingerprints`**
- **bump rigour to see if it builds**
- **upgrade rigour and see if this passes**
- **actual test failure!**
- **refacor**
- **clean imports**
- **Build docs using Python 3.12**
- **up rigour to support py 3.10**
- **remove pre-installs**
- **up rigour for py 3.10**
- **Move all RDF export code into one module**
- **Remove random RDF mappings from schema spec**
- **Clean up references in test cases, and untangle from node_id**
- **Mint URIs ad-hoc**
- **one day I'll get this right**
- **Force resolution on some schema fields, refs #1732**
- **Add a hidden field that allows us to filter sanctions targets by which programs they're sanctioned under.**
- **generate default model**
- **Remove bad/deprecated property**
- **Bump typescript from 5.8.2 to 5.8.3 in /js (#1746)**
- **Bump @types/node from 22.13.16 to 22.15.3 in /js (#1742)**
- **Bump vite from 6.2.6 to 6.3.4 in /docs (#1734)**
- **Bump rollup from 4.38.0 to 4.40.1 in /js (#1739)**
- **Bump @eslint/js from 9.24.0 to 9.25.1 in /js (#1740)**
- **Bump jackson.version from 2.18.3 to 2.19.0 in /java (#1736)**
- **Bump lint-staged from 15.5.0 to 15.5.1 in /js (#1744)**
- **Bump org.junit:junit-bom from 5.12.1 to 5.12.2 in /java (#1735)**
- **Bump typescript-eslint from 8.29.0 to 8.31.1 in /js (#1737)**
- **Bump eslint from 9.23.0 to 9.25.1 in /js (#1745)**
- **Bump ts-jest from 29.3.1 to 29.3.2 in /js (#1743)**
- **Bump astro from 5.6.1 to 5.7.10 in /docs (#1747)**
- **Fix typo in schema, fixes #1748**
- **Make Sanction.duration into a number**
- **update default model**
- **Remove: data is outdated, and mechanism not used**
- **rename inverse**
- **generate model**
- **Re-name CompositeEntity to StatementEntity**
- **Introduce `model.matchable_schemata`**
- **Tighten down requirements on proxy.id, schema.get**
- **Explicitly instantiate types (#1752)**
- **implement `property.caption` to handle identifier formats**
- **Simplify imports**
- **Refactor property value handling, introduce a more narrow type annotation than `Any`.**
- **Make Model a proper singleton, don't pass it through everywhere (#1751)**
- **Expose more classes at the package root**
- **Add a hidden field that allows us to filter sanctions targets by which programs they're sanctioned under.**
- **remove direct dependency on stdnum**
- **forced labor topic**
- **re-name**
- **and back**
- **generate model**
- **try and fix docker build**
- **add icu-devtools**
- **keep throwing dependencies at the problem**
- **Bump version: 3.8.2 → 3.8.3**
- **Numbers with units parsing**
- **Add format option**
- **Re-name topic and cache some checks**
- **Bump version: 3.8.3 → 3.8.4**
- **Bump org.junit:junit-bom from 5.12.2 to 5.13.0 in /java**
- **Bump @alephdata/followthemoney from 3.8.2 to 3.8.4 in /docs (#1771)**
- **Bump astro from 5.7.10 to 5.8.1 in /docs (#1770)**
- **till fb 1: remove License:location in favor of License:address.**
- **till fb 2: consolidate caption handling**
- **Fix type warning on StatementEntity.merge**
- **tp feedback 3: remove registry.iban**
- **Derive model values**
- **Remove prop_type denormalisation**
- **Fix type issues, and dangling IBAN references**
- **mypy innovations**
- **Fix type checker**
- **re-instate side effect**
- **Bump org.apache.maven.plugins:maven-clean-plugin in /java (#1769)**
- **handle more specific types**
- **feat: ensure valid dataset names**
- **test: add one other case**
- **add round tripping of statement dict with tests**
- **Implement extras and origin with some tests**
- **begin project re-homing**
- **Revert "begin project re-homing"**
- **begin project re-homing**
- **enable workflow dispatch**
- **Remove discourse integration**
- **Update dependabot.yml**
- **turn it off**
- **and on again**
- **main build action**
- **Fix options file for docs**
- **update docs dependencies**
- **upgrade js dependencies**
- **Fix link**
- **Update more references to aleph->os/oa**
- **Bump org.junit:junit-bom from 5.13.0 to 5.13.2 in /java (#13)**
- **Bump jackson.version from 2.19.0 to 2.19.1 in /java (#14)**
- **Bump org.sonatype.central:central-publishing-maven-plugin in /java (#18)**
- **do only origin for now**
- **Update issues URL**
- **move astro to the side**
- **Basic mkdocs skeleton**
- **more deps**
- **Metadata edits**
- **Modernize a few legacy Python things**
- **Fix up imports**
- **How about this for CSVWriter?**
- **any way the wind blows...**
- **Bump version: 3.8.4 → 3.8.5**
- **Install instructions**
- **Add origin to Java statement model**
- **Inline StreamEntity from nomenklatura**
- **Adjust to model singleton**
- **add type annotation to Row**
- **Add conversion test for StreamEntity**
- **Copy over most of the markdown docs from astro**
- **update import**
- **StreamEntity -> ValueEntity, improve**
- **Write copy and begin explorer**
- **Fix images and cli docs**
- **Edit CLI docs a bit**
- **Begin making this mkdocsy**
- **(docs) Boilerplate schemata pages**
- **Bring in awesome-ftm**
- **(docs) Add inheritance graph viz and improve schema detail page**
- **Make tables full width**
- **Community commentary**
- **generate loads of schema doc stubs**
- **(docs/stack) Fix list formatting**
- **(docs/schema) Add ref to props**
- **Add links to the schema doc in some places**
- **(docs/schema) Render empty str for None description**
- **(docs/schema/custom) Fix schema refs**
- **Add more FAQ copy**
- **Begin type descriptions**
- **More links in docs**
- **Remove astro documentation**
- **Build mkdocs**
- **lots of type docs, other language libraries**
- **(docs/schema) Inline prop description in Label column**
- **(docs/schema) Rework schema detail page**
- **(docs) Customize footer**
- **Much copy, slightly chaotic**
- **Work on documentation**
- **Phone type docs**
- **An art.**
- **More work on types docs**
- **Countries type page**
- **Include country and identifier descriptions**
- **Bump @eslint/js from 9.29.0 to 9.30.1 in /js (#42)**
- **Bump typescript-eslint from 8.35.0 to 8.35.1 in /js (#44)**
- **Bump eslint from 9.29.0 to 9.30.1 in /js (#47)**
- **Bump @types/node from 24.0.4 to 24.0.10 in /js (#46)**
- **Bump @rollup/plugin-typescript from 12.1.3 to 12.1.4 in /js (#48)**
- **fix type warning with arg name**
- **identifiers edits**
- **Add prop_type to Statement db row**
- **Use SubtleCrypto for generating namespace hmac, fixes #39**
- **Some documentation edits**
- **include ValueEntity in documentation**
- **www!**
- **Remove astro depandabot**
- **Bump org.apache.maven.plugins:maven-gpg-plugin in /java (#51)**
- **Expand documentation for number type**
- **Make project descriptions more expressive**
- **more grammar**
- **(fix) Re-enable EntityProxy as value for entity property**
- **Fix broken links to new oa location**
- **Add a few comments to the Javadoc**
- **Throw instead of `hasattr`**
- **Make it awkward**
- **Type checker be cracking up**
- **Such broken much wow**
- **Add chinese USCC**
- **Can't help myself to bring in interning**
- **Use pydantic models for catalog / dataset metadata**
- **Fix semantics table rendering for no edges**
- **Lean into Pydantic a bit more**
- **Expand imports**
- **Bump org.apache.commons:commons-lang3 in /java in the maven group (#63)**
- **Add headers and statement IDs to pack format**
- **Fix some concerns raised by copilot**
- **up some dependencies**
- **Try and fix some links**
- **Bump version: 3.8.5 → 4.0.0**
- **update video link**
- **Small perf tuning from nk store upgrades**
- **Make the dataset class more easily subclassable**
- **revert the sub-type, figured out another solution**
- **use iterable for values**
- **lint**
- **Helpers for making rigour name objects from FtM schema**
- **Some commentary**
- **Bump version: 4.0.0 → 4.0.1**
- **emails and test_invalid_emails csv**
- **clean_local_part and clean_domain_part for email validation**
- **call clean_domain and clean_local from clean_text**
- **DatasetResource: dump mime_type_label**
- **latinize non latin function**
- **Clean instead of just validate DataResource.mime_type**
- **Add a test for the dataset export json**
- **Remove .Model abstraction - doesn't work**
- **add a few more entity tests**
- **clean clean_text**
- **Some more testing**
- **Fix for Py 3.10**
- **Bump version: 4.0.1 → 4.0.2**
- **clean clean_domain_part and clean_local_part**
- **rstrip the dot in the clean text**
- **more tests**
- **test data removed and useful regex added**
- **Update tests/types/test_emails.py**
- **Fix country_label being exported on publisher**
- **Bump version: 4.0.2 → 4.0.3**
- **Fix handling of None entity.id in EntityProxy and Namespace**
- **Fix typing**
- **update links**
- **Adapt some normality 3 type warnings**
- **Update a few more calls**
- **Try less fixing, more checking and discarding**
- **One regex is enough for everybody**
- **Bump version: 4.0.3 → 4.1.0**
- **fix up to normality 3.0.1**
- **normality replacement**
- **don't ask, don't tell - minimal perf gain for large exports**
- **Add test for valueentity reading statement entities**
- **bump requirements**
- **Bump version: 4.1.0 → 4.1.1**
- **Add origin to StatementEntity context**
- **Bump org.apache.commons:commons-csv from 1.14.0 to 1.14.1 in /java**
- **Bump cross-env from 7.0.3 to 10.0.0 in /js**
- **Update a bunch of JS libs**
- **update java deps**
- **Replace countrynames with rigour.lookup_territory**
- **hide TOC in all schemata, sort listings, backport witticism**
- **clear unused slot**
- **Create risk schema model for future use, refs #7.**
- **regenerate derived data**
- **Bump version: 4.1.1 → 4.1.2**
- **helpers.combine_names: Don't modify the name parts in the entity passed**
- **helpers: Also use matronymic in combine_names**
- **helpers.combine_names: Use cheaper string joining**
- **fix: add __slots__ to ValueEntity for pickling**
- **Introduce list of risk topics**
- **Update model**
- **Expand a bit**
- **Maritime matters, fixes #1.**
- **build model**
- **Bump version: 4.1.2 → 4.2.0**
- **Validate property names**
- **Consider statement language when picking a caption**
- **review fixes**
- **Bump org.apache.maven.plugins:maven-javadoc-plugin in /java**
- **Fight with dependabot a fair bit**
- **re-structure the sidebar**
- **Bump eslint from 9.32.0 to 9.34.0 in /js**
- **Bump actions/upload-pages-artifact from 3 to 4**
- **Bump actions/setup-java from 4 to 5**
- **Bump rollup from 4.46.2 to 4.50.0 in /js**
- **Bump actions/checkout from 4 to 5**
- **Bump version: 4.2.0 → 4.2.1**
- **Better descriptions for some classifiers/identifier on companies**
