### PR TITLE
Deprecate Person:secondName because it's too ambiguous

### DIFF
--- a/followthemoney/schema/Person.yaml
+++ b/followthemoney/schema/Person.yaml
@@ -33,17 +33,24 @@ Person:
     # too many false positives.
     firstName:
       label: First name
+      description: "The part of a name that indicates the person, also often called given name or forename"
       rdf: http://xmlns.com/foaf/0.1/givenName
     secondName:
       label: Second name
+      description: "Deprecated, use a more specific property such as `firstName`, `middleName`, `matro-/patronymic` or `lastName` instead."
+      deprecated: true
     middleName:
       label: Middle name
+      description: "The part of name written between a person's given name (`firstName`) and family name (`lastName`). Often abbreviated as a middle initial."
     fatherName:
       label: Patronymic
+      description: "The part of a name based on the given name of one's father"
     motherName:
       label: Matronymic
+      description: "The part of a name based on the given name of one's mother"
     lastName:
       label: Last name
+      description: "The part of a name that indicates one's family, also often called surname or family name"
       rdf: http://xmlns.com/foaf/0.1/lastName
     nameSuffix:
       label: Name suffix


### PR DESCRIPTION
Claude says the following about what "second name" means in English:

> American English: "Second name" typically refers to a middle name
> British English: Can refer to either middle name or surname, though this creates some ambiguity

It's not really clear what it means, so discourage its use.

See https://github.com/opensanctions/opensanctions/issues/2728
