### PR TITLE
fix: Return entity match score 1.0 for self-similarity

### DIFF
--- a/followthemoney/compare.py
+++ b/followthemoney/compare.py
@@ -71,13 +71,39 @@ def _compare(scores: Scores, weights: Weights, n_std: int = 1) -> float:
     return 1.0 / (1.0 + math.exp(-prob))
 
 
+def properties_are_same(
+        left: EntityProxy,
+        right: EntityProxy
+) -> bool:
+    """Check if the properties of two entities are the same."""
+    if not left.properties or not right.properties:
+        return False
+    for prop in set(left.properties.keys()).union(right.properties.keys()):
+        a_vals = sorted(set(left.properties.get(prop, [])))
+        b_vals = sorted(set(right.properties.get(prop, [])))
+        if a_vals != b_vals:
+            return False
+    return True
+
+
+def entity_is_same(
+        left: EntityProxy,
+        right: EntityProxy
+) -> bool:
+    """Check if two entities are the same apart from their ID."""
+    if left.schema.name != right.schema.name:
+        return False
+
+    return properties_are_same(left, right)
+
+
 def compare(
     left: EntityProxy,
     right: EntityProxy,
     weights: Weights = COMPARE_WEIGHTS,
 ) -> float:
     """Compare two entities and return a match score."""
-    if left.__eq__(right):
+    if entity_is_same(left, right):
         return 1.0
     scores = compare_scores(left, right)
     return _compare(scores, weights)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -2,7 +2,7 @@ import pytest
 from copy import deepcopy
 
 from followthemoney import model
-from followthemoney.compare import compare, compare_names
+from followthemoney.compare import compare, compare_names, entity_is_same
 
 
 ENTITY = {
@@ -74,3 +74,27 @@ def test_compare_quality():
     reduced["properties"]["name"] = ["Frank Banana"]
     reduced_proxy = model.get_proxy(reduced)
     assert compare(entity, reduced_proxy) < best_score
+
+
+def test_is_equal():
+    # Check that self-comparison returns True
+    left = {
+        "schema": "Person",
+        "properties": {"name": ["mr frank banana", "f. banana"]}
+    }
+    left = model.get_proxy(left)
+    assert entity_is_same(left, left)
+    # Check that different schema returns False
+    right = {
+        "schema": "Organization",
+        "properties": {"name": ["mr frank banana", "f. banana"]},
+    }
+    right = model.get_proxy(right)
+    assert not entity_is_same(left, right)
+    # Check that different properties returns False
+    right = {
+        "schema": "Person",
+        "properties": {"name": ["mr frank bananoid"]},
+    }
+    right = model.get_proxy(right)
+    assert not entity_is_same(left, right)


### PR DESCRIPTION
## Issue: 
Comparing an entity to itself does not return a match score of 1.0 due to the logistic scoring function in `compare._compare`.

## Solution:
This PR adds a check for entity equality in `compare.compare`, returning a match score of 1.0 if an entity is being compared to itself.

### Example:
```py
from followthemoney import model

entity_A = {"id": "1", "schema": "LegalEntity", "properties": {"name": ["A"], "jurisdiction": ["X"]}}
entity_B = {"id": "2", "schema": "LegalEntity", "properties": {"name": ["A"], "jurisdiction": ["X"]}}

left = model.get_proxy(entity_A)
right = model.get_proxy(entity_B)

match_score_AA = compare.compare(left=left, right=left)
match_score_AB = compare.compare(left=left, right=right)
```
Prior behavior:
```bash
match_score_AA: 0.8037275008485661
match_score_AB: 0.8037275008485661
```
New behavior:
```bash
match_score_AA: 1.0
match_score_AB: 0.8037275008485661
```