### PR TITLE
Other name -> Alias and better docs for weakAlias

### DIFF
--- a/followthemoney/schema/Thing.yaml
+++ b/followthemoney/schema/Thing.yaml
@@ -24,7 +24,7 @@ Thing:
       label: Country
       type: country
     alias:
-      label: Other name
+      label: Alias
       type: name
     previousName:
       label: Previous name
@@ -32,6 +32,7 @@ Thing:
     weakAlias:
       label: Weak alias
       type: name
+      description: "A relatively broad or generic alias that should not be used for matching in screening systems. It may still may be useful for identification purposes, particularly in confirming a possible match triggered by other identifier information."
       matchable: false
     sourceUrl:
       label: Source link


### PR DESCRIPTION
Sort of copied from OFAC:
  
  > A "weak AKA" is a term for a relatively broad or generic alias that may generate a large volume of false hits when such names are run through a computer-based screening system.  OFAC includes these AKAs because, based on information available to it, the sanctions targets refer to themselves, or are referred to, by these names. As a result, these AKAs may be useful for identification purposes, particularly in confirming a possible "hit" or "match" triggered by other identifier information. Realizing, however, the large number of false hits that these names may generate, OFAC qualitatively distinguishes them from other AKAs by designating them as weak.
  