### PR TITLE
ValueEntity: Inherit to_dict data from EntityProxy

### DIFF
--- a/followthemoney/entity.py
+++ b/followthemoney/entity.py
@@ -81,9 +81,6 @@ class ValueEntity(EntityProxy):
     def to_dict(self) -> Dict[str, Any]:
         data = super().to_dict()
         extra_data: Dict[str, Any] = {
-            "id": self.id,
-            "schema": self.schema.name,
-            "properties": self.properties,
             "referents": list(self.referents),
             "datasets": list(self.datasets),
         }


### PR DESCRIPTION
Hey there,

this is open to discuss if you want this or not:

We over at OpenAleph, if we want to introduce "ValueEntity" as the new default Entity class implementation (for some kind of forward migration purposes ;)) it needs to properly inherit the to_dict method from `EntityProxy` as this contains the original `context`, from which we need stuff like `mutable: True` for the UI.

On another hand, I can see that it'd be worth to completly get rid of extra context for the `ValueEntity` and if an application still depends on this, it should stick to passing around `EntityProxy`.

Either way works for us, just let us know what you think :)