### PR TITLE
Add JSON dataset query DSL

### DIFF
--- a/docs/docs/metadata.md
+++ b/docs/docs/metadata.md
@@ -149,6 +149,39 @@ Exclude multiple datasets at once using nested `not`/`or`:
 ]}
 ```
 
+### String syntax
+
+For use in URLs, CLI arguments, or configuration files, queries can also be written as compact strings using `parse_query`:
+
+```python
+from followthemoney.dataset import parse_query, evaluate_query
+
+query = parse_query("(#issuer.west|#list.sanction)-lt_fiu-#issuer.ru")
+results = evaluate_query(catalog, query)
+```
+
+The string syntax uses three operators, listed by precedence (high to low):
+
+| Operator | Meaning | JSON equivalent |
+|----------|---------|-----------------|
+| `()` | Grouping | Nesting |
+| `&` | Intersection | `and` |
+| `-` | Subtraction | `and` + `not` |
+| `\|` | Union | `or` |
+
+`&` and `-` bind tighter than `|`, so `a|b&c` is parsed as `a|(b&c)`.
+
+Subtraction desugars into `and` + `not`:
+
+| String | JSON AST |
+|--------|----------|
+| `sanctions` | `"sanctions"` |
+| `a\|b\|c` | `{"or": ["a", "b", "c"]}` |
+| `a&b` | `{"and": ["a", "b"]}` |
+| `a-b` | `{"and": ["a", {"not": "b"}]}` |
+| `(a\|b)-c` | `{"and": [{"or": ["a", "b"]}, {"not": "c"}]}` |
+| `(#issuer.west\|#list.sanction)-lt_fiu-#issuer.ru` | `{"and": [{"or": ["#issuer.west", "#list.sanction"]}, {"not": "lt_fiu"}, {"not": "#issuer.ru"}]}` |
+
 ## Relevant standards
 
 The dataset specification in FtM is largely based on Google's [schema.org/Dataset](https://schema.org/Dataset), which allows for SEO-friendly markup on dataset pages. Various similar specifications exist, for example the W3C's [Data Catalog Vocabulary (DCAT)](https://www.w3.org/TR/vocab-dcat-3/) and the [Frictionless Data Package](https://specs.frictionlessdata.io/data-package/).

--- a/docs/docs/metadata.md
+++ b/docs/docs/metadata.md
@@ -52,7 +52,7 @@ The most important piece of metadata for any dataset is its `name`. Names are lo
 
 ## Dataset query DSL
 
-The Python library includes a small JSON-based query DSL for filtering datasets by name, collection membership, or tags. It is available as `followthemoney.dataset.evaluate_query`:
+The Python library includes a small query DSL for filtering datasets by name, collection membership, or tags. It is available as `followthemoney.dataset.evaluate_query`:
 
 ```python
 from followthemoney.dataset import DataCatalog, Dataset, evaluate_query
@@ -78,7 +78,7 @@ DatasetQuery = str | list[DatasetQuery]
 |---------|---------|---------|
 | `"datasetname"` | A specific dataset by slug | `"us_ofac_sdn"` |
 | `"collectionname"` | A collection, expanded to its leaf datasets | `"sanctions"` |
-| `"#scope.value"` | All datasets matching a tag | `"#issuer.eu"` |
+| `"#tag"` | All datasets matching a tag | `"#issuer.eu"` |
 
 The `#` prefix is query syntax only — the stored tag value is `issuer.eu`, not `#issuer.eu`. Collections are always expanded to their leaf datasets.
 

--- a/docs/docs/metadata.md
+++ b/docs/docs/metadata.md
@@ -50,6 +50,105 @@ The most important piece of metadata for any dataset is its `name`. Names are lo
 |             | `size`            | Size of the resource in bytes                          |
 
 
+## Dataset query DSL
+
+The Python library includes a small JSON-based query DSL for filtering datasets by name, collection membership, or tags. It is available as `followthemoney.dataset.evaluate_query`:
+
+```python
+from followthemoney.dataset import DataCatalog, Dataset, evaluate_query
+
+catalog = DataCatalog.from_path(Dataset, "catalog.yml")
+results = evaluate_query(catalog, {"and": ["#issuer.eu", "#list.sanction"]})
+```
+
+### Grammar
+
+A query is a recursive structure with three operators and string leaves:
+
+```
+DatasetQuery = str | list[DatasetQuery]
+             | {"or": list[DatasetQuery]}
+             | {"and": list[DatasetQuery]}
+             | {"not": DatasetQuery}
+```
+
+### Leaf values
+
+| Pattern | Meaning | Example |
+|---------|---------|---------|
+| `"datasetname"` | A specific dataset by slug | `"us_ofac_sdn"` |
+| `"collectionname"` | A collection, expanded to its leaf datasets | `"sanctions"` |
+| `"#scope.value"` | All datasets matching a tag | `"#issuer.eu"` |
+
+The `#` prefix is query syntax only — the stored tag value is `issuer.eu`, not `#issuer.eu`. Collections are always expanded to their leaf datasets.
+
+### Operators
+
+**`or`** — union of all sub-queries:
+
+```json
+{"or": ["#list.sanction", "#list.debarment"]}
+```
+
+**`and`** — intersection of all sub-queries:
+
+```json
+{"and": ["#issuer.eu", "#list.sanction"]}
+```
+
+**`not`** — complement (all datasets in the catalog *except* the matched ones):
+
+```json
+{"not": "lt_fiu_sanctions"}
+```
+
+A bare list is shorthand for `or`, so `["a", "b"]` is equivalent to `{"or": ["a", "b"]}`.
+
+### Examples
+
+A single dataset:
+
+```json
+"us_ofac_sdn"
+```
+
+Multiple datasets:
+
+```json
+["us_ofac_sdn", "eu_fsf", "gb_hmt_sanctions"]
+```
+
+All datasets tagged as sanctions:
+
+```json
+"#list.sanction"
+```
+
+EU-issued sanctions lists:
+
+```json
+{"and": ["#issuer.eu", "#list.sanction"]}
+```
+
+Western sanctions and debarments, excluding a specific dataset and all Russian-issued sources:
+
+```json
+{"and": [
+    {"or": ["#issuer.west", "#list.sanction", "#list.debarment"]},
+    {"not": "lt_fiu_sanctions"},
+    {"not": "#issuer.ru"}
+]}
+```
+
+Exclude multiple datasets at once using nested `not`/`or`:
+
+```json
+{"and": [
+    "#list.sanction",
+    {"not": {"or": ["lt_fiu_sanctions", "ru_fedsfm"]}}
+]}
+```
+
 ## Relevant standards
 
 The dataset specification in FtM is largely based on Google's [schema.org/Dataset](https://schema.org/Dataset), which allows for SEO-friendly markup on dataset pages. Various similar specifications exist, for example the W3C's [Data Catalog Vocabulary (DCAT)](https://www.w3.org/TR/vocab-dcat-3/) and the [Frictionless Data Package](https://specs.frictionlessdata.io/data-package/).

--- a/followthemoney/dataset/__init__.py
+++ b/followthemoney/dataset/__init__.py
@@ -3,6 +3,7 @@ from followthemoney.dataset.catalog import DataCatalog
 from followthemoney.dataset.resource import DataResource
 from followthemoney.dataset.publisher import DataPublisher
 from followthemoney.dataset.coverage import DataCoverage
+from followthemoney.dataset.query import DatasetQuery, evaluate_query, validate_query
 
 UndefinedDataset = Dataset.make({"name": Dataset.UNDEFINED})
 
@@ -14,4 +15,7 @@ __all__ = [
     "DataPublisher",
     "DataCoverage",
     "DS",
+    "DatasetQuery",
+    "evaluate_query",
+    "validate_query",
 ]

--- a/followthemoney/dataset/__init__.py
+++ b/followthemoney/dataset/__init__.py
@@ -4,6 +4,7 @@ from followthemoney.dataset.resource import DataResource
 from followthemoney.dataset.publisher import DataPublisher
 from followthemoney.dataset.coverage import DataCoverage
 from followthemoney.dataset.query import DatasetQuery, evaluate_query, validate_query
+from followthemoney.dataset.parse import parse_query
 
 UndefinedDataset = Dataset.make({"name": Dataset.UNDEFINED})
 
@@ -17,5 +18,6 @@ __all__ = [
     "DS",
     "DatasetQuery",
     "evaluate_query",
+    "parse_query",
     "validate_query",
 ]

--- a/followthemoney/dataset/parse.py
+++ b/followthemoney/dataset/parse.py
@@ -1,0 +1,110 @@
+"""String query parser for the dataset filter DSL.
+
+Parses compact string expressions like ``(#issuer.west|#list.sanction)-lt_fiu``
+into a ``DatasetQuery`` JSON AST that can be evaluated with ``evaluate_query``.
+
+See https://followthemoney.tech/docs/metadata/#dataset-query-dsl for full
+documentation and examples.
+"""
+
+from typing import List
+
+from followthemoney.dataset.query import DatasetQuery
+from followthemoney.exc import InvalidDatasetQuery
+
+_LEAF_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.#"
+)
+
+
+class _Parser:
+    """Recursive descent parser for the string query syntax."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.pos = 0
+
+    def _skip_whitespace(self) -> None:
+        while self.pos < len(self.text) and self.text[self.pos] == " ":
+            self.pos += 1
+
+    def _peek(self) -> str:
+        self._skip_whitespace()
+        if self.pos >= len(self.text):
+            return ""
+        return self.text[self.pos]
+
+    def _consume(self, expected: str) -> None:
+        self._skip_whitespace()
+        if self.pos >= len(self.text) or self.text[self.pos] != expected:
+            raise InvalidDatasetQuery(
+                "Expected %r at position %d" % (expected, self.pos)
+            )
+        self.pos += 1
+
+    def _parse_leaf(self) -> str:
+        self._skip_whitespace()
+        start = self.pos
+        while self.pos < len(self.text) and self.text[self.pos] in _LEAF_CHARS:
+            self.pos += 1
+        if self.pos == start:
+            raise InvalidDatasetQuery(
+                "Expected identifier at position %d" % self.pos
+            )
+        return self.text[start : self.pos]
+
+    def _parse_atom(self) -> DatasetQuery:
+        if self._peek() == "(":
+            self._consume("(")
+            result = self._parse_or()
+            self._consume(")")
+            return result
+        return self._parse_leaf()
+
+    def _parse_and(self) -> DatasetQuery:
+        items: List[DatasetQuery] = [self._parse_atom()]
+        while self._peek() in ("&", "-"):
+            op = self.text[self.pos]
+            self.pos += 1
+            atom = self._parse_atom()
+            if op == "-":
+                items.append({"not": atom})
+            else:
+                items.append(atom)
+        if len(items) == 1:
+            return items[0]
+        return {"and": items}
+
+    def _parse_or(self) -> DatasetQuery:
+        items: List[DatasetQuery] = [self._parse_and()]
+        while self._peek() == "|":
+            self.pos += 1
+            items.append(self._parse_and())
+        if len(items) == 1:
+            return items[0]
+        return {"or": items}
+
+    def parse(self) -> DatasetQuery:
+        if len(self.text.strip()) == 0:
+            raise InvalidDatasetQuery("Empty query string")
+        result = self._parse_or()
+        self._skip_whitespace()
+        if self.pos < len(self.text):
+            raise InvalidDatasetQuery(
+                "Unexpected character %r at position %d"
+                % (self.text[self.pos], self.pos)
+            )
+        return result
+
+
+def parse_query(text: str) -> DatasetQuery:
+    """Parse a string query into a DatasetQuery AST.
+
+    Syntax: ``(#issuer.west|#list.sanction)-lt_fiu-#issuer.ru``
+
+    Operators by precedence (high to low):
+    - ``()`` grouping
+    - ``&`` intersection, ``-`` subtraction (same precedence, left-to-right)
+    - ``|`` union
+    """
+    return _Parser(text).parse()

--- a/followthemoney/dataset/parse.py
+++ b/followthemoney/dataset/parse.py
@@ -1,7 +1,7 @@
 """String query parser for the dataset filter DSL.
 
 Parses compact string expressions like ``(#issuer.west|#list.sanction)-lt_fiu``
-into a ``DatasetQuery`` JSON AST that can be evaluated with ``evaluate_query``.
+into a ``DatasetQuery`` that can be evaluated with ``evaluate_query``.
 
 See https://followthemoney.tech/docs/metadata/#dataset-query-dsl for full
 documentation and examples.

--- a/followthemoney/dataset/query.py
+++ b/followthemoney/dataset/query.py
@@ -1,7 +1,7 @@
-"""Dataset filter DSL — JSON AST evaluation.
+"""Dataset filter DSL — AST evaluation.
 
 Provides ``evaluate_query(catalog, query)`` to filter datasets using a recursive
-JSON structure with ``or``, ``and``, and ``not`` operators. Leaf values are
+dictionary structure with ``or``, ``and``, and ``not`` operators. Leaf values are
 dataset names, collection names (expanded to leaves), or ``#tag`` selectors.
 
 See https://followthemoney.tech/docs/metadata/#dataset-query-dsl for full
@@ -9,6 +9,7 @@ documentation and examples.
 """
 
 from collections.abc import Mapping, Sequence
+import functools
 from typing import Any, Dict, List, Set, TYPE_CHECKING, Union
 
 from followthemoney.dataset.dataset import DS
@@ -91,15 +92,11 @@ def _evaluate(catalog: "DataCatalog[DS]", query: DatasetQuery) -> Set[DS]:
         key = next(iter(query))
         value = query[key]
         if key == "or":
-            result = set()
-            for item in value:
-                result.update(_evaluate(catalog, item))
-            return result
+            results = [_evaluate(catalog, item) for item in value]
+            return functools.reduce(set.union, results)
         if key == "and":
-            result = _evaluate(catalog, value[0])
-            for item in value[1:]:
-                result = result & _evaluate(catalog, item)
-            return result
+            results = [_evaluate(catalog, item) for item in value]
+            return functools.reduce(set.intersection, results)
         if key == "not":
             return _universe(catalog) - _evaluate(catalog, value)
     raise InvalidDatasetQuery("Invalid query node type: %s" % type(query).__name__)
@@ -108,7 +105,7 @@ def _evaluate(catalog: "DataCatalog[DS]", query: DatasetQuery) -> Set[DS]:
 def evaluate_query(catalog: "DataCatalog[DS]", query: DatasetQuery) -> Set[DS]:
     """Evaluate a query AST against a catalog, returning matching leaf datasets.
 
-    The query is a JSON-like structure using "or", "and", and "not" operators.
+    The query is a dictionary-like structure using "or", "and", and "not" operators.
     Leaf strings are dataset names, collection names, or "#tag" selectors.
     A bare list is treated as an implicit "or".
     """

--- a/followthemoney/dataset/query.py
+++ b/followthemoney/dataset/query.py
@@ -8,6 +8,7 @@ See https://followthemoney.tech/docs/metadata/#dataset-query-dsl for full
 documentation and examples.
 """
 
+from collections.abc import Mapping, Sequence
 from typing import Any, Dict, List, Set, TYPE_CHECKING, Union
 
 from followthemoney.dataset.dataset import DS
@@ -27,13 +28,13 @@ def validate_query(query: Any) -> None:
         if len(query) == 0:
             raise InvalidDatasetQuery("Empty string in query")
         return
-    if isinstance(query, list):
+    if isinstance(query, Sequence):
         if len(query) == 0:
             raise InvalidDatasetQuery("Empty array in query")
         for item in query:
             validate_query(item)
         return
-    if isinstance(query, dict):
+    if isinstance(query, Mapping):
         if len(query) != 1:
             raise InvalidDatasetQuery("Operator object must have exactly one key")
         key = next(iter(query))
@@ -43,8 +44,10 @@ def validate_query(query: Any) -> None:
         if key == "not":
             validate_query(value)
         else:
-            if not isinstance(value, list) or len(value) == 0:
-                raise InvalidDatasetQuery("Operator %r requires a non-empty array" % key)
+            if not isinstance(value, Sequence) or isinstance(value, str) or len(value) == 0:
+                raise InvalidDatasetQuery(
+                    "Operator %r requires a non-empty array" % key
+                )
             for item in value:
                 validate_query(item)
         return
@@ -79,12 +82,12 @@ def _evaluate(catalog: "DataCatalog[DS]", query: DatasetQuery) -> Set[DS]:
     """Recursively evaluate a query AST against a catalog."""
     if isinstance(query, str):
         return _resolve_leaf(catalog, query)
-    if isinstance(query, list):
+    if isinstance(query, Sequence):
         result: Set[DS] = set()
         for item in query:
             result.update(_evaluate(catalog, item))
         return result
-    if isinstance(query, dict):
+    if isinstance(query, Mapping):
         key = next(iter(query))
         value = query[key]
         if key == "or":

--- a/followthemoney/dataset/query.py
+++ b/followthemoney/dataset/query.py
@@ -60,10 +60,10 @@ def _resolve_leaf(catalog: "DataCatalog[DS]", leaf: str) -> Set[DS]:
             if tag in ds.model.tags:
                 result.update(ds.leaves)
         return result
-    ds = catalog.get(leaf)
-    if ds is None:
+    dataset = catalog.get(leaf)
+    if dataset is None:
         raise InvalidDatasetQuery("Unknown dataset: %r" % leaf)
-    return ds.leaves
+    return dataset.leaves
 
 
 def _universe(catalog: "DataCatalog[DS]") -> Set[DS]:

--- a/followthemoney/dataset/query.py
+++ b/followthemoney/dataset/query.py
@@ -1,0 +1,113 @@
+"""Dataset filter DSL — JSON AST evaluation.
+
+Provides ``evaluate_query(catalog, query)`` to filter datasets using a recursive
+JSON structure with ``or``, ``and``, and ``not`` operators. Leaf values are
+dataset names, collection names (expanded to leaves), or ``#tag`` selectors.
+
+See https://followthemoney.tech/docs/metadata/#dataset-query-dsl for full
+documentation and examples.
+"""
+
+from typing import Any, Dict, List, Set, TYPE_CHECKING, Union
+
+from followthemoney.dataset.dataset import DS
+from followthemoney.exc import InvalidDatasetQuery
+
+if TYPE_CHECKING:
+    from followthemoney.dataset.catalog import DataCatalog
+
+DatasetQuery = Union[str, List[Any], Dict[str, Any]]
+
+OPERATORS = frozenset(("or", "and", "not"))
+
+
+def validate_query(query: Any) -> None:
+    """Check that a query conforms to the DSL grammar. Raises InvalidDatasetQuery on failure."""
+    if isinstance(query, str):
+        if len(query) == 0:
+            raise InvalidDatasetQuery("Empty string in query")
+        return
+    if isinstance(query, list):
+        if len(query) == 0:
+            raise InvalidDatasetQuery("Empty array in query")
+        for item in query:
+            validate_query(item)
+        return
+    if isinstance(query, dict):
+        if len(query) != 1:
+            raise InvalidDatasetQuery("Operator object must have exactly one key")
+        key = next(iter(query))
+        if key not in OPERATORS:
+            raise InvalidDatasetQuery("Unknown operator: %r" % key)
+        value = query[key]
+        if key == "not":
+            validate_query(value)
+        else:
+            if not isinstance(value, list) or len(value) == 0:
+                raise InvalidDatasetQuery("Operator %r requires a non-empty array" % key)
+            for item in value:
+                validate_query(item)
+        return
+    raise InvalidDatasetQuery("Invalid query node type: %s" % type(query).__name__)
+
+
+def _resolve_leaf(catalog: "DataCatalog[DS]", leaf: str) -> Set[DS]:
+    """Resolve a leaf string to a set of leaf datasets."""
+    if leaf.startswith("#"):
+        tag = leaf[1:]
+        result: Set[DS] = set()
+        for ds in catalog.datasets:
+            if tag in ds.model.tags:
+                result.update(ds.leaves)
+        return result
+    ds = catalog.get(leaf)
+    if ds is None:
+        raise InvalidDatasetQuery("Unknown dataset: %r" % leaf)
+    return ds.leaves
+
+
+def _universe(catalog: "DataCatalog[DS]") -> Set[DS]:
+    """Return all leaf datasets in the catalog."""
+    result: Set[DS] = set()
+    for ds in catalog.datasets:
+        if not ds.is_collection:
+            result.add(ds)
+    return result
+
+
+def _evaluate(catalog: "DataCatalog[DS]", query: DatasetQuery) -> Set[DS]:
+    """Recursively evaluate a query AST against a catalog."""
+    if isinstance(query, str):
+        return _resolve_leaf(catalog, query)
+    if isinstance(query, list):
+        result: Set[DS] = set()
+        for item in query:
+            result.update(_evaluate(catalog, item))
+        return result
+    if isinstance(query, dict):
+        key = next(iter(query))
+        value = query[key]
+        if key == "or":
+            result = set()
+            for item in value:
+                result.update(_evaluate(catalog, item))
+            return result
+        if key == "and":
+            result = _evaluate(catalog, value[0])
+            for item in value[1:]:
+                result = result & _evaluate(catalog, item)
+            return result
+        if key == "not":
+            return _universe(catalog) - _evaluate(catalog, value)
+    raise InvalidDatasetQuery("Invalid query node type: %s" % type(query).__name__)
+
+
+def evaluate_query(catalog: "DataCatalog[DS]", query: DatasetQuery) -> Set[DS]:
+    """Evaluate a query AST against a catalog, returning matching leaf datasets.
+
+    The query is a JSON-like structure using "or", "and", and "not" operators.
+    Leaf strings are dataset names, collection names, or "#tag" selectors.
+    A bare list is treated as an implicit "or".
+    """
+    validate_query(query)
+    return _evaluate(catalog, query)

--- a/followthemoney/exc.py
+++ b/followthemoney/exc.py
@@ -35,3 +35,9 @@ class InvalidMapping(FollowTheMoneyException):
     """A data mapping was invalid."""
 
     pass
+
+
+class InvalidDatasetQuery(FollowTheMoneyException):
+    """A dataset query DSL expression was invalid."""
+
+    pass

--- a/followthemoney/schema/Thing.yaml
+++ b/followthemoney/schema/Thing.yaml
@@ -66,6 +66,7 @@ Thing:
     wikipediaUrl:
       label: Wikipedia Article
       type: url
+      matchable: false
     wikidataId:
       label: Wikidata ID
       type: identifier

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,6 +1,7 @@
 import pytest
 from followthemoney.dataset import Dataset, DataCatalog
 from followthemoney.dataset.query import evaluate_query, validate_query
+from followthemoney.dataset.parse import parse_query
 from followthemoney.exc import InvalidDatasetQuery
 
 
@@ -170,3 +171,114 @@ def test_validate_query_accepts_complex_query():
             {"not": "lt_fiu"},
         ]
     })
+
+
+# --- parse_query tests ---
+
+
+def test_parse_single_leaf():
+    assert parse_query("sanctions") == "sanctions"
+
+
+def test_parse_tag():
+    assert parse_query("#issuer.eu") == "#issuer.eu"
+
+
+def test_parse_or():
+    assert parse_query("a|b|c") == {"or": ["a", "b", "c"]}
+
+
+def test_parse_and():
+    assert parse_query("a&b") == {"and": ["a", "b"]}
+
+
+def test_parse_subtract():
+    assert parse_query("a-b") == {"and": ["a", {"not": "b"}]}
+
+
+def test_parse_subtract_chain():
+    assert parse_query("a-b-c") == {"and": ["a", {"not": "b"}, {"not": "c"}]}
+
+
+def test_parse_and_with_subtract():
+    assert parse_query("a&b-c") == {"and": ["a", "b", {"not": "c"}]}
+
+
+def test_parse_precedence_or_lower_than_and():
+    assert parse_query("a|b&c") == {"or": ["a", {"and": ["b", "c"]}]}
+
+
+def test_parse_parens():
+    assert parse_query("(a|b)-c") == {"and": [{"or": ["a", "b"]}, {"not": "c"}]}
+
+
+def test_parse_nested_parens():
+    assert parse_query("(a&(b|c))-d") == {
+        "and": [{"and": ["a", {"or": ["b", "c"]}]}, {"not": "d"}]
+    }
+
+
+def test_parse_issue_example():
+    result = parse_query("(#issuer.west|#list.sanction|#list.debarment)-lt_fiu-#issuer.ru")
+    assert result == {
+        "and": [
+            {"or": ["#issuer.west", "#list.sanction", "#list.debarment"]},
+            {"not": "lt_fiu"},
+            {"not": "#issuer.ru"},
+        ]
+    }
+
+
+def test_parse_whitespace_tolerance():
+    assert parse_query("a | b & c") == parse_query("a|b&c")
+
+
+def test_parse_roundtrip_with_evaluate(catalog):
+    result = evaluate_query(
+        catalog,
+        parse_query("(#issuer.west|#list.sanction)-lt_fiu-#issuer.ru"),
+    )
+    assert names(result) == {"us_ofac_sdn", "eu_fsf", "gb_hmt", "world_bank_debarred"}
+
+
+def test_parse_empty_string():
+    with pytest.raises(InvalidDatasetQuery, match="Empty query"):
+        parse_query("")
+
+
+def test_parse_empty_whitespace():
+    with pytest.raises(InvalidDatasetQuery, match="Empty query"):
+        parse_query("   ")
+
+
+def test_parse_unmatched_open_paren():
+    with pytest.raises(InvalidDatasetQuery, match="Expected"):
+        parse_query("(a|b")
+
+
+def test_parse_unmatched_close_paren():
+    with pytest.raises(InvalidDatasetQuery, match="Unexpected character"):
+        parse_query("a|b)")
+
+
+def test_parse_deeply_nested_parens():
+    assert parse_query("((a|b)&(c|d))-e") == {
+        "and": [
+            {"and": [{"or": ["a", "b"]}, {"or": ["c", "d"]}]},
+            {"not": "e"},
+        ]
+    }
+
+
+def test_parse_redundant_parens():
+    assert parse_query("((a))") == "a"
+
+
+def test_parse_empty_parens():
+    with pytest.raises(InvalidDatasetQuery, match="Expected identifier"):
+        parse_query("()")
+
+
+def test_parse_trailing_operator():
+    with pytest.raises(InvalidDatasetQuery, match="Expected identifier"):
+        parse_query("a|")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,172 @@
+import pytest
+from followthemoney.dataset import Dataset, DataCatalog
+from followthemoney.dataset.query import evaluate_query, validate_query
+from followthemoney.exc import InvalidDatasetQuery
+
+
+def make_catalog():
+    """Build a small catalog with datasets, collections, and tags."""
+    catalog = DataCatalog(Dataset, {})
+    catalog.make_dataset(
+        {"name": "us_ofac_sdn", "title": "US OFAC SDN", "tags": ["list.sanction", "issuer.us", "issuer.west"]}
+    )
+    catalog.make_dataset(
+        {"name": "eu_fsf", "title": "EU Financial Sanctions", "tags": ["list.sanction", "issuer.eu", "issuer.west"]}
+    )
+    catalog.make_dataset(
+        {"name": "gb_hmt", "title": "UK HMT Sanctions", "tags": ["list.sanction", "issuer.gb", "issuer.west"]}
+    )
+    catalog.make_dataset(
+        {"name": "ru_fedsfm", "title": "Russia Fedsfm", "tags": ["list.sanction", "issuer.ru"]}
+    )
+    catalog.make_dataset(
+        {"name": "lt_fiu", "title": "Lithuania FIU", "tags": ["list.sanction", "issuer.west"]}
+    )
+    catalog.make_dataset(
+        {"name": "world_bank_debarred", "title": "World Bank Debarred", "tags": ["list.debarment", "issuer.west"]}
+    )
+    catalog.make_dataset(
+        {"name": "sanctions", "title": "All Sanctions", "children": ["us_ofac_sdn", "eu_fsf", "gb_hmt", "ru_fedsfm", "lt_fiu"]}
+    )
+    return catalog
+
+
+@pytest.fixture
+def catalog():
+    return make_catalog()
+
+
+def names(result):
+    return {d.name for d in result}
+
+
+def test_resolve_single_dataset(catalog):
+    result = evaluate_query(catalog, "us_ofac_sdn")
+    assert names(result) == {"us_ofac_sdn"}
+
+
+def test_resolve_collection_expands_to_leaves(catalog):
+    result = evaluate_query(catalog, "sanctions")
+    assert names(result) == {"us_ofac_sdn", "eu_fsf", "gb_hmt", "ru_fedsfm", "lt_fiu"}
+
+
+def test_resolve_tag_selector(catalog):
+    result = evaluate_query(catalog, "#issuer.eu")
+    assert names(result) == {"eu_fsf"}
+
+
+def test_resolve_tag_multiple_matches(catalog):
+    result = evaluate_query(catalog, "#list.sanction")
+    assert names(result) == {"us_ofac_sdn", "eu_fsf", "gb_hmt", "ru_fedsfm", "lt_fiu"}
+
+
+def test_resolve_unknown_dataset_raises(catalog):
+    with pytest.raises(InvalidDatasetQuery, match="Unknown dataset"):
+        evaluate_query(catalog, "nonexistent")
+
+
+def test_resolve_tag_no_matches(catalog):
+    result = evaluate_query(catalog, "#issuer.cn")
+    assert result == set()
+
+
+def test_operator_or(catalog):
+    result = evaluate_query(catalog, {"or": ["us_ofac_sdn", "eu_fsf"]})
+    assert names(result) == {"us_ofac_sdn", "eu_fsf"}
+
+
+def test_operator_and(catalog):
+    result = evaluate_query(catalog, {"and": ["#issuer.west", "#list.sanction"]})
+    assert names(result) == {"us_ofac_sdn", "eu_fsf", "gb_hmt", "lt_fiu"}
+
+
+def test_operator_not(catalog):
+    result = evaluate_query(catalog, {"not": "ru_fedsfm"})
+    assert "ru_fedsfm" not in names(result)
+    assert "us_ofac_sdn" in names(result)
+    assert "world_bank_debarred" in names(result)
+
+
+def test_bare_array_is_implicit_or(catalog):
+    result = evaluate_query(catalog, ["us_ofac_sdn", "eu_fsf"])
+    assert names(result) == {"us_ofac_sdn", "eu_fsf"}
+
+
+def test_and_with_not_for_subtraction(catalog):
+    """(#issuer.west & #list.sanction) - lt_fiu"""
+    result = evaluate_query(catalog, {
+        "and": [
+            {"or": ["#issuer.west", "#list.sanction"]},
+            {"not": "lt_fiu"},
+        ]
+    })
+    assert "lt_fiu" not in names(result)
+    assert "us_ofac_sdn" in names(result)
+
+
+def test_western_sanctions_minus_exclusions(catalog):
+    """(#issuer.west|#list.sanction|#list.debarment)-lt_fiu-#issuer.ru"""
+    result = evaluate_query(catalog, {
+        "and": [
+            {"or": ["#issuer.west", "#list.sanction", "#list.debarment"]},
+            {"not": "lt_fiu"},
+            {"not": "#issuer.ru"},
+        ]
+    })
+    assert names(result) == {"us_ofac_sdn", "eu_fsf", "gb_hmt", "world_bank_debarred"}
+
+
+def test_nested_or_inside_not(catalog):
+    """Exclude multiple datasets via not(or(...))"""
+    result = evaluate_query(catalog, {
+        "and": [
+            "#list.sanction",
+            {"not": {"or": ["lt_fiu", "ru_fedsfm"]}},
+        ]
+    })
+    assert names(result) == {"us_ofac_sdn", "eu_fsf", "gb_hmt"}
+
+
+def test_collection_name_in_and_with_tag(catalog):
+    """Use a collection name alongside a tag in and."""
+    result = evaluate_query(catalog, {"and": ["sanctions", "#issuer.west"]})
+    assert names(result) == {"us_ofac_sdn", "eu_fsf", "gb_hmt", "lt_fiu"}
+
+
+def test_validate_query_rejects_empty_string():
+    with pytest.raises(InvalidDatasetQuery, match="Empty string"):
+        validate_query("")
+
+
+def test_validate_query_rejects_empty_array():
+    with pytest.raises(InvalidDatasetQuery, match="Empty array"):
+        validate_query([])
+
+
+def test_validate_query_rejects_unknown_operator():
+    with pytest.raises(InvalidDatasetQuery, match="Unknown operator"):
+        validate_query({"xor": ["a", "b"]})
+
+
+def test_validate_query_rejects_multiple_keys():
+    with pytest.raises(InvalidDatasetQuery, match="exactly one key"):
+        validate_query({"or": ["a"], "and": ["b"]})
+
+
+def test_validate_query_rejects_or_without_array():
+    with pytest.raises(InvalidDatasetQuery, match="non-empty array"):
+        validate_query({"or": "a"})
+
+
+def test_validate_query_rejects_invalid_type():
+    with pytest.raises(InvalidDatasetQuery, match="Invalid query node type"):
+        validate_query(42)
+
+
+def test_validate_query_accepts_complex_query():
+    validate_query({
+        "and": [
+            {"or": ["#issuer.west", "#list.sanction"]},
+            {"not": "lt_fiu"},
+        ]
+    })


### PR DESCRIPTION
## Summary

Implements a minimal JSON-based query DSL for filtering datasets by name, collection membership, or tags (#199). Instead of writing a custom string parser, the DSL is specified as a JSON AST (per @leonhandreke's suggestion), similar to Elasticsearch or MongoDB queries.

- **New module** `followthemoney/dataset/query.py` with `evaluate_query(catalog, query)` and `validate_query(query)`
- **New exception** `InvalidDatasetQuery` in `followthemoney/exc.py`
- **Documentation** added to `docs/docs/metadata.md` with grammar, operator reference, and examples
- **21 tests** covering leaf resolution, operators, composition, collection expansion, tag matching, and validation

### DSL overview

Three operators (`or`, `and`, `not`) over string leaves (dataset names, collection names, `#tag` selectors):

```json
{"and": [
    {"or": ["#issuer.west", "#list.sanction", "#list.debarment"]},
    {"not": "lt_fiu_sanctions"},
    {"not": "#issuer.ru"}
]}
```

Collections are expanded to their leaf datasets. Tags use the `#` prefix as query syntax (stored value is e.g. `issuer.eu`).

Closes #199

## Test plan

- [x] `pytest tests/test_query.py` — 21 tests pass
- [x] Full suite `pytest` — 196 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)