### PR TITLE
Add Version, VersionHistory to followthemoney.dataset

### DIFF
--- a/followthemoney/dataset/__init__.py
+++ b/followthemoney/dataset/__init__.py
@@ -6,6 +6,7 @@ from followthemoney.dataset.coverage import DataCoverage
 from followthemoney.dataset.query import DatasetQuery, evaluate_query, match_datasets
 from followthemoney.dataset.query import validate_query
 from followthemoney.dataset.parse import parse_query
+from followthemoney.dataset.versions import Version, VersionHistory
 
 UndefinedDataset = Dataset.make({"name": Dataset.UNDEFINED})
 
@@ -22,4 +23,6 @@ __all__ = [
     "match_datasets",
     "parse_query",
     "validate_query",
+    "Version",
+    "VersionHistory",
 ]

--- a/followthemoney/dataset/versions.py
+++ b/followthemoney/dataset/versions.py
@@ -1,0 +1,125 @@
+import json
+import os
+import random
+import string
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterator, List, Optional
+
+from rigour.time import utc_now
+
+
+class Version(object):
+    """A class to represent a dataset version, which consists of a timestamp
+    and a string tag."""
+
+    __slots__ = ["dt", "tag"]
+
+    def __init__(self, dt: datetime, tag: str) -> None:
+        self.dt: datetime = dt
+        self.tag: str = tag
+
+    @classmethod
+    def new(cls, tag: Optional[str] = None) -> "Version":
+        now = utc_now().replace(tzinfo=None)
+
+        if tag is None:
+            # This keeps the tag sortable but short.
+            tag_num = (now.microsecond // 1000) * 10
+            tag_num_ = tag_num + random.randint(0, 9)
+            tag = cls._tag_encode(int(tag_num_))
+
+        tag = tag.ljust(3, "x")[:3]
+        now = now.replace(microsecond=0)
+        return cls(now, tag)
+
+    @classmethod
+    def from_string(cls, id: str) -> "Version":
+        if "-" not in id:
+            raise ValueError(f"Invalid dataset version: {id}")
+        ts, tag = id.split("-", 1)
+        dt = datetime.strptime(ts, "%Y%m%d%H%M%S")
+        dt = dt.replace(tzinfo=None)
+        return cls(dt, tag)
+
+    @classmethod
+    def _tag_encode(cls, number: int, alphabet: str = string.ascii_lowercase) -> str:
+        """Converts an integer to a base36 string."""
+        assert number >= 0, "number must be positive"
+        if 0 <= number < len(alphabet):
+            return alphabet[number]
+
+        encoded = ""
+        while number != 0:
+            number, i = divmod(number, len(alphabet))
+            encoded = alphabet[i] + encoded
+        return encoded
+
+    @classmethod
+    def from_env(cls, name: str) -> "Version":
+        id = os.environ.get(name)
+        if id is None:
+            return cls.new()
+        return cls.from_string(id)
+
+    @property
+    def id(self) -> str:
+        return f"{self.dt.strftime('%Y%m%d%H%M%S')}-{self.tag}"
+
+    def __str__(self) -> str:
+        return self.id
+
+    def __repr__(self) -> str:
+        return f"Version({self.id})"
+
+    def __eq__(self, other: Any) -> bool:
+        return self.id == str(other)
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+
+@dataclass
+class VersionHistory(object):
+    """A class to represent a history of dataset versions."""
+
+    LENGTH = 100
+
+    items: List[Version]
+    last_successful: Optional[Version] = None
+    max_length: int = LENGTH
+
+    def append(self, version: Version) -> "VersionHistory":
+        """Creates a new history with the given RunID appended."""
+        items = list(self.items)
+        items.append(version)
+        return VersionHistory(items[-self.max_length :], self.last_successful)
+
+    @property
+    def latest(self) -> Optional[Version]:
+        if not len(self.items):
+            return None
+        return self.items[-1]
+
+    def to_json(self) -> str:
+        """Return a JSON representation of the version history."""
+        items = [str(run) for run in self.items[-self.LENGTH :]]
+        last_successful = self.last_successful.id if self.last_successful else None
+        return json.dumps({"items": items, "last_successful": last_successful})
+
+    @classmethod
+    def from_json(cls, data: str) -> "VersionHistory":
+        """Create a run history from a JSON representation."""
+        items_raw = json.loads(data).get("items", [])
+        last_successful_raw = json.loads(data).get("last_successful", None)
+        items = [Version.from_string(item_raw) for item_raw in items_raw]
+        last_successful = (
+            Version.from_string(last_successful_raw) if last_successful_raw else None
+        )
+        return cls(items=items, last_successful=last_successful)
+
+    def __iter__(self) -> Iterator[Version]:
+        return iter(self.items)
+
+    def __len__(self) -> int:
+        return len(self.items)

--- a/tests/dataset/test_versions.py
+++ b/tests/dataset/test_versions.py
@@ -1,0 +1,83 @@
+import os
+from typing import Optional
+
+import pytest
+
+from followthemoney.dataset.versions import Version, VersionHistory
+
+
+def test_version() -> None:
+    runid = Version.new("aaa")
+    assert runid.id.startswith(runid.dt.strftime("%Y%m%d%H%M%S"))
+    assert len(runid.tag) == 3
+    assert len(runid.id) == 18
+    assert str(runid) == runid.id
+    assert repr(runid) == f"Version({runid.id})"
+    runid2 = Version.new("bbb")
+    assert runid2.id != runid.id
+    assert hash(runid2) == hash(runid2.id)
+
+    with pytest.raises(ValueError):
+        Version.from_string("foo")
+
+    os.environ["NK_RUN_ID"] = runid.id
+    runid3 = Version.from_env("NK_RUN_ID")
+    assert runid3.id == runid.id
+
+    runid4 = Version.from_env("NK_RUN2222_ID")
+    assert runid4.id != runid2.id
+
+    prev_id: Optional[Version] = None
+    for i in range(100):
+        next_id = Version.new()
+        if prev_id is not None:
+            assert next_id.dt >= prev_id.dt, (next_id, prev_id)
+        prev_id = next_id
+
+
+def test_run_history() -> None:
+    original = VersionHistory([])
+    assert original.latest is None
+    assert original.to_json() == '{"items": [], "last_successful": null}'
+
+    runid = Version.new()
+    history = original.append(runid)
+    assert len(history) == 1
+    assert len(original) == 0
+    assert history.latest == runid
+    assert history.last_successful is None
+    assert history.to_json() == f'{{"items": ["{runid.id}"], "last_successful": null}}'
+
+    history.last_successful = runid
+    assert (
+        history.to_json()
+        == f'{{"items": ["{runid.id}"], "last_successful": "{runid.id}"}}'
+    )
+    assert history.last_successful == runid
+
+    runid2 = Version.new()
+    history = history.append(runid2)
+    assert history.latest == runid2
+    assert (
+        history.to_json()
+        == f'{{"items": ["{runid.id}", "{runid2.id}"], "last_successful": "{runid.id}"}}'
+    )
+    assert len(list(history)) == 2
+    # check that the last_successful is not updated automatically
+    assert history.last_successful == runid
+
+    # test that the load-store cycle works
+    other = VersionHistory.from_json(history.to_json())
+    assert other.latest == runid2
+    assert other.last_successful == runid
+
+    for _ in range(10000):
+        history = history.append(Version.new())
+        assert len(history) <= VersionHistory.LENGTH
+
+    history = VersionHistory([runid, runid2])
+    assert history.latest == runid2
+    assert (
+        history.to_json()
+        == f'{{"items": ["{runid.id}", "{runid2.id}"], "last_successful": null}}'
+    )


### PR DESCRIPTION
## Summary
- Port `Version` and `VersionHistory` from `nomenklatura.versions` to `followthemoney.dataset.versions`, alongside their tests.
- Companion PR in nomenklatura turns `nomenklatura.versions` into a thin deprecation shim that re-exports from here; downstream callers (zavod, yente, etc.) continue working unchanged until they migrate.

## Test plan
- [x] `pytest tests/dataset/test_versions.py` passes
- [x] `mypy --strict followthemoney/dataset/versions.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)