### PR TITLE
Add model version field + publish model.json per release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -13,6 +13,16 @@ replace = version = "{new_version}"
 search = "version": "{current_version}"
 replace = "version": "{new_version}"
 
+# Keep the version baked into the dumped model in step with the bump, so CI's
+# `make default-model` diff check stays green without a regen on every bump.
+[bumpversion:file:js/src/defaultModel.json]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
+
+[bumpversion:file:java/src/main/resources/defaultModel.json]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
+
 [bumpversion:file:java/pom.xml]
 search = <version><!-- bump -->{current_version}</version>
 replace = <version><!-- bump -->{new_version}</version>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,25 @@ jobs:
           skip-existing: true
           verbose: true
 
+  # Attach the dumped model to the GitHub Release so each version has a stable,
+  # path-independent URL:
+  #   .../releases/download/<tag>/model.json   (immutable, per-version)
+  #   .../releases/latest/download/model.json  (floating "latest" pointer)
+  # The bytes are the same ones the `python` job verified are up to date.
+  model:
+    runs-on: ubuntu-latest
+    needs: python
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Stage the model as model.json
+        run: cp js/src/defaultModel.json model.json
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: model.json
+
   nodejs:
     runs-on: ubuntu-latest
     strategy:

--- a/followthemoney/model.py
+++ b/followthemoney/model.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 class ModelToDict(TypedDict):
     schemata: Dict[str, SchemaToDict]
     types: Dict[str, PropertyTypeToDict]
+    version: str
 
 
 class Model(object):
@@ -179,7 +180,10 @@ class Model(object):
 
     def to_dict(self) -> ModelToDict:
         """Return metadata for all schemata and properties, in a serializable form."""
+        from followthemoney import __version__
+
         return {
+            "version": __version__,
             "schemata": {s.name: s.to_dict() for s in self.schemata.values()},
             "types": {t.name: t.to_dict() for t in registry.types},
         }

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -8373,5 +8373,6 @@
       "pivot": true,
       "plural": "URLs"
     }
-  }
+  },
+  "version": "4.8.3"
 }

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -8373,5 +8373,6 @@
       "pivot": true,
       "plural": "URLs"
     }
-  }
+  },
+  "version": "4.8.3"
 }


### PR DESCRIPTION
Two related changes around versioning and publishing the FtM model.

## `version` field in the dumped model
`ftm dump-model` (and the committed `defaultModel.json` files) now carry a top-level `version`, so a consumer of a `defaultModel.json` can tell which release it came from.

To avoid a `make default-model` regen on every release, both committed dumps are wired into `.bumpversion.cfg` with a targeted search/replace. The version string appears exactly once per file, so the bump moves it in lockstep and CI's `make default-model` diff check stays green. A real schema change still goes through `make default-model` as before, which now also writes the current version into the field.

## `model.json` release asset
On tag pushes, the dumped model is attached to the GitHub Release as `model.json`, giving each version a stable, path-independent URL:

- `…/releases/download/<tag>/model.json` — immutable, per-version
- `…/releases/latest/download/model.json` — floating "latest" pointer

The bytes are the same `js/src/defaultModel.json` the `python` job already verifies is up to date; it's staged as `model.json` purely for a clean asset name. The job gets its own `contents: write` (top-level perms stay `read`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)