### PR TITLE
Add invest.ban topic for investment bans

### DIFF
--- a/followthemoney/types/topic.py
+++ b/followthemoney/types/topic.py
@@ -93,6 +93,7 @@ class TopicType(EnumType):
         "export.control.linked": _("Export control-linked"),
         "export.risk": _("Trade risk"),
         "invest.risk": _("Investment risk"),
+        "invest.ban": _("Investment ban"),
         "debarment": _("Debarred entity"),
         "poi": _("Person of interest"),
     }
@@ -112,6 +113,7 @@ class TopicType(EnumType):
         "export.control.linked",
         "export.risk",
         "invest.risk",
+        "invest.ban",
         "poi",
         "mare.detained",
         "mare.shadow",

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -8331,6 +8331,7 @@
         "gov.security": "Security services",
         "gov.soe": "State-owned enterprise",
         "gov.state": "State government",
+        "invest.ban": "Investment ban",
         "invest.risk": "Investment risk",
         "mare.detained": "Maritime detention",
         "mare.shadow": "Shadow fleet",

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -8331,6 +8331,7 @@
         "gov.security": "Security services",
         "gov.soe": "State-owned enterprise",
         "gov.state": "State government",
+        "invest.ban": "Investment ban",
         "invest.risk": "Investment risk",
         "mare.detained": "Maritime detention",
         "mare.shadow": "Shadow fleet",


### PR DESCRIPTION
Adds an `invest.ban` ("Investment ban") topic to the controlled vocabulary, alongside the existing `invest.risk`. It's also added to the `RISKS` set, since an investment ban implies a counterparty risk in business dealings.

Verified: cleans correctly, resolves to the "Investment ban" label, and is flagged in `RISKS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)