### PR TITLE
Migrate SBOM attestation to actions/attest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,7 +235,7 @@ jobs:
           upload-artifact: false
       - name: Attest SBOM to OCI registry
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-        uses: actions/attest-sbom@v2
+        uses: actions/attest@v4
         with:
           subject-name: ghcr.io/opensanctions/followthemoney
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
`actions/attest-sbom` is deprecated as of v4 — it's now just a wrapper over [`actions/attest`](https://github.com/actions/attest), which exposes a native `sbom-path` input with the same SPDX/CycloneDX auto-detection. This migrates the SBOM attestation step in `build.yml` directly to `actions/attest@v4`; all four inputs (`subject-name`, `subject-digest`, `sbom-path`, `push-to-registry`) carry over unchanged.

This keeps us on the maintained line and matches the existing `actions/attest-build-provenance@v4` step.

Supersedes #298 (Dependabot's `attest-sbom` v2→v4 bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)