### PR TITLE
Add sanction.control topic for ownership/control derivation

### DIFF
--- a/followthemoney/types/topic.py
+++ b/followthemoney/types/topic.py
@@ -87,6 +87,7 @@ class TopicType(EnumType):
         "mil": _("Military"),
         "sanction": _("Sanctioned entity"),
         "sanction.linked": _("Sanction-linked entity"),
+        "sanction.control": _("Sanction ownership or control"),
         "sanction.counter": _("Counter-sanctioned entity"),
         "export.control": _("Export controlled"),
         # For BIS 50% rule:
@@ -122,6 +123,7 @@ class TopicType(EnumType):
         "role.oligarch",
         "role.pep",
         "role.rca",
+        "sanction.control",
         "sanction.counter",
         "sanction.linked",
         "sanction",

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -8369,6 +8369,7 @@
         "role.rca": "Close Associate",
         "role.spy": "Spy",
         "sanction": "Sanctioned entity",
+        "sanction.control": "Sanction ownership or control",
         "sanction.counter": "Counter-sanctioned entity",
         "sanction.linked": "Sanction-linked entity",
         "wanted": "Wanted"

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -8369,6 +8369,7 @@
         "role.rca": "Close Associate",
         "role.spy": "Spy",
         "sanction": "Sanctioned entity",
+        "sanction.control": "Sanction ownership or control",
         "sanction.counter": "Counter-sanctioned entity",
         "sanction.linked": "Sanction-linked entity",
         "wanted": "Wanted"


### PR DESCRIPTION
Introduces a new `topics` value **`sanction.control`** — label **"Sanction ownership or control"** — to capture entities pulled into sanctions scope via the 50%-rule / control doctrine, rather than the vaguer existing `sanction.linked`.

### Why this key and label

The major frameworks diverge in mechanism:

- **OFAC** and **BIS** apply an **ownership-only** test (50% rule).
- **EU** and **UK** apply to entities **owned _or_ controlled** by a designated person — control can attach without majority ownership.

A single key labelled "Sanction ownership or control" spans both dimensions without asserting which mechanism applies or implying the threshold math has been done — the more precise "weasel language" requested in the issue.

### Changes

- `followthemoney/types/topic.py` — added to `_TOPICS` and to the `RISKS` set (derived-sanction status is a counterparty risk).
- `js/src/defaultModel.json`, `java/src/main/resources/defaultModel.json` — regenerated via `ftm dump-model`.

### Out of scope (follow-ups)

- Downstream crawlers in `zavod`/`opensanctions` that would emit the topic.
- Translation catalog (`make translate` / `pybabel extract`).

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)