### PR TITLE
Add `ftm ref` model-browsing CLI command group

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -36,7 +36,7 @@ Commands exchange entities as newline-delimited JSON — one entity object per l
 
 Streams can be piped through multiple commands without decoding overhead, and large files can be processed incrementally. If you need a human-readable view, pipe through [`ftm pretty`](#formatting-streams).
 
-The writer always emits `id` as the first key in each line. Because the lines are sortable as plain text — every line starts with `{"id":"<id>"` — a standard `sort` pipeline orders an entity stream by ID without any JSON-aware tooling. The same property holds for line-based statement streams, which begin with `{"canonical_id":"<id>"`.
+The writer always emits `id` as the first key in each line. Because the lines are sortable as plain text (every line starts with `{"id":"<id>"`), a standard `sort` pipeline orders an entity stream by ID without any JSON-aware tooling. The same property holds for line-based statement streams, which begin with `{"canonical_id":"<id>"`.
 
 This matters because Unix `sort` is fast, uses external merge sort to spill to disk when the input exceeds memory, and parallelizes across cores with `--parallel`. It scales to datasets of tens or hundreds of gigabytes without special infrastructure, which is what makes [`ftm sorted-aggregate`](#aggregating-fragments) and [`ftm aggregate-statements`](#statement-based-workflows) practical beyond what `ftm aggregate` can handle in memory.
 
@@ -44,7 +44,7 @@ This matters because Unix `sort` is fast, uses external merge sort to spill to d
 
 ### Executing a mapping
 
-Mappings project structured data (CSV or SQL) into FtM entities according to a [YAML mapping file](mappings.md). Run a mapping with `ftm map`:
+Mappings project structured data (CSV or SQL) into FollowTheMoney (FtM) entities according to a [YAML mapping file](mappings.md). Run a mapping with `ftm map`:
 
 ```bash
 curl -o md_companies.yml https://raw.githubusercontent.com/alephdata/aleph/main/mappings/md_companies.yml
@@ -89,7 +89,7 @@ See the [mappings reference](mappings.md) for the YAML schema, including keys, f
 cat raw.ijson | ftm validate > clean.ijson
 ```
 
-If a producer emits unclean data — stray whitespace, invalid country codes, malformed dates — validation normalizes what it can and drops the rest.
+If a producer emits unclean data (stray whitespace, invalid country codes, malformed dates), validation normalizes what it can and drops the rest.
 
 ### Formatting for humans
 
@@ -110,6 +110,26 @@ ftm dump-model -o model.json
 ```
 
 This is the same model described by the [schema explorer](../explorer/schemata/index.md), serialized for tools that want to consume it programmatically.
+
+## Exploring the schema model
+
+Where `ftm dump-model` emits the entire model at once, `ftm ref` lets you browse it one question at a time: which schemata exist, what properties a `Person` accepts, what type a property holds, what values an enum allows. It reads the model compiled into the installed `followthemoney` package, so it is always in sync with your version, works offline, and needs no API key. It is built for coding agents and humans who want an answer without reading the YAML sources or piping `dump-model` through `jq`.
+
+Every `ref` command prints a table when attached to a terminal and JSON when piped or when `--json` is passed. So `ftm ref schema Person` is readable at a prompt, and `ftm ref schema Person | jq` produces JSON for tooling:
+
+```bash
+ftm ref                       # model overview + the subcommand index
+ftm ref schemata              # every schema, with matchable/abstract flags
+ftm ref schemata --matchable  # only schemata that can be matched
+ftm ref schema Person         # one schema, with all inherited properties
+ftm ref types                 # every property type
+ftm ref type country          # one type, including its enum values
+ftm ref prop Person:nationality   # one property's full definition
+```
+
+`ftm ref schema NAME` lists the complete property set: own properties plus everything inherited from ancestor schemata. That is exactly the set of fields you can set on an entity of that schema. Stub (reverse-edge) properties are hidden by default; pass `--stubs` to include them. A property is addressed by its qualified `Schema:property` name, and inherited names resolve against the schema you ask about: `ftm ref prop Person:name` works even though `name` is defined on `Thing`.
+
+Unknown names produce a `Did you mean: …?` suggestion and exit with a usage error, so a mistyped schema or property fails fast rather than silently returning nothing.
 
 ## Namespace signing
 
@@ -259,7 +279,7 @@ This requires stopping the Neo4J server and running the generated script against
 
 #### GEXF for Gephi
 
-[GEXF](https://gephi.org/gexf/format/) is the graph format used by [Gephi](https://gephi.org/) and related tools. Use it for quantitative graph analysis — centrality, PageRank, force-directed layouts — on graphs of tens of thousands of nodes:
+[GEXF](https://gephi.org/gexf/format/) is the graph format used by [Gephi](https://gephi.org/) and related tools. Use it for quantitative graph analysis (centrality, PageRank, force-directed layouts) on graphs of tens of thousands of nodes:
 
 ```bash
 cat us_ofac.ijson | ftm validate | ftm export-gexf -e iban -o ofac.gexf

--- a/followthemoney/cli/ref.py
+++ b/followthemoney/cli/ref.py
@@ -20,6 +20,7 @@ from followthemoney.types import registry
 from followthemoney.types.common import EnumType
 from followthemoney.schema import Schema
 from followthemoney.property import Property
+from followthemoney.cli.cli import cli
 from followthemoney.cli.render import is_json_mode, emit_json, print_table
 
 JSON_OPTION = click.option(
@@ -79,13 +80,13 @@ def _prop_flags(prop: Property) -> str:
 
 
 def _prop_payload(prop: Property) -> Dict[str, Any]:
-    """JSON shape for a property within a schema listing: to_dict + origin."""
+    """JSON shape for a property within a schema listing: to_dict + origin schema."""
     data: Dict[str, Any] = dict(prop.to_dict())
-    data["from_schema"] = prop.schema.name
+    data["schema"] = prop.schema.name
     return data
 
 
-@click.group("ref", invoke_without_command=True, help="Browse the FtM model offline.")
+@cli.group("ref", invoke_without_command=True, help="Browse the FtM model offline.")
 @JSON_OPTION
 @click.pass_context
 def ref(ctx: click.Context, json_flag: bool) -> None:
@@ -181,35 +182,27 @@ def ref_schema(ctx: click.Context, name: str, stubs: bool, json_flag: bool) -> N
         return
 
     props = [p for p in schema.sorted_properties if stubs or not p.stub]
-    summary: Dict[str, Any] = {
-        "name": schema.name,
-        "label": schema.label,
-        "description": (schema.description or "").strip(),
-        "matchable": schema.matchable,
-        "abstract": schema.abstract,
-        "hidden": schema.hidden,
-        "generated": schema.generated,
-        "deprecated": schema.deprecated,
-        # All ancestors (transitive), not just direct parents.
-        "extends": sorted(s.name for s in schema.schemata if s != schema),
-        "descendants": sorted(s.name for s in schema.descendants),
-        "featured": list(schema.featured),
-        "required": list(schema.required),
-        "properties": [_prop_payload(p) for p in props],
-    }
+    # Start from the model's own serialization so new schema fields flow through
+    # automatically; override the few views `ref` presents differently.
+    extends = sorted(s.name for s in schema.schemata if s != schema)
+    summary: Dict[str, Any] = dict(schema.to_dict())
+    summary["name"] = schema.name
+    summary["extends"] = extends  # all ancestors, not just direct parents
+    summary["descendants"] = sorted(s.name for s in schema.descendants)
+    summary["properties"] = [_prop_payload(p) for p in props]
 
     if _json_mode(ctx, json_flag):
         emit_json(summary)
         return
 
     click.echo(f"{schema.name}  ({schema.label})")
-    if summary["description"]:
-        click.echo(summary["description"])
+    if schema.description:
+        click.echo(schema.description.strip())
     click.echo("")
     click.echo(f"  matchable:    {'yes' if schema.matchable else 'no'}")
-    click.echo(f"  extends:      {', '.join(summary['extends']) or '(none)'}")
-    click.echo(f"  featured:     {', '.join(summary['featured']) or '(none)'}")
-    click.echo(f"  required:     {', '.join(summary['required']) or '(none)'}")
+    click.echo(f"  extends:      {', '.join(extends) or '(none)'}")
+    click.echo(f"  featured:     {', '.join(schema.featured) or '(none)'}")
+    click.echo(f"  required:     {', '.join(schema.required) or '(none)'}")
     click.echo("")
     rows = [
         [
@@ -242,6 +235,7 @@ def _type_detail(ctx: click.Context, name: str, json_flag: bool) -> None:
         )
         return
 
+    is_enum = isinstance(type_, EnumType)
     using = sorted(
         (
             {"qname": p.qname, "schema": p.schema.name, "name": p.name}
@@ -250,8 +244,10 @@ def _type_detail(ctx: click.Context, name: str, json_flag: bool) -> None:
         ),
         key=lambda p: p["qname"],
     )
+    # to_dict() omits the type's own name; carry it so the payload self-identifies.
     data: Dict[str, Any] = dict(type_.to_dict())
     data["name"] = type_.name
+    data["enum"] = is_enum
     data["properties"] = using
 
     if _json_mode(ctx, json_flag):
@@ -264,16 +260,9 @@ def _type_detail(ctx: click.Context, name: str, json_flag: bool) -> None:
     click.echo("")
     click.echo(f"  matchable:  {'yes' if type_.matchable else 'no'}")
     click.echo(f"  pivot:      {'yes' if type_.pivot else 'no'}")
+    click.echo(f"  enum:       {'yes' if is_enum else 'no'}")
     click.echo(f"  group:      {type_.group or '(none)'}")
     click.echo("")
-
-    if isinstance(type_, EnumType):
-        values = type_.names
-        rows = [[code, label] for code, label in sorted(values.items())]
-        print_table(
-            rows, headers=["value", "label"], caption=f"{len(values)} enum value(s)"
-        )
-        click.echo("")
 
     prop_rows = [[p["qname"], p["schema"]] for p in using]
     print_table(
@@ -281,6 +270,14 @@ def _type_detail(ctx: click.Context, name: str, json_flag: bool) -> None:
         headers=["property", "schema"],
         caption=f"{len(using)} property/properties of type {type_.name!r}",
     )
+
+    if isinstance(type_, EnumType):
+        click.echo("")
+        values = type_.names
+        rows = [[code, label] for code, label in sorted(values.items())]
+        print_table(
+            rows, headers=["value", "label"], caption=f"{len(values)} supported value(s)"
+        )
 
 
 @ref.command("types", help="List property types, or detail one with [NAME].")
@@ -411,11 +408,3 @@ def ref_prop(ctx: click.Context, qname: str, json_flag: bool) -> None:
             headers=["value", "label"],
             caption=f"{len(prop.type.names)} value(s) for type {prop.type.name!r}",
         )
-
-
-# Attach to the root CLI group so `ftm ref ...` works whether the command is
-# loaded via the entry point or by importing this module directly (tests).
-from followthemoney.cli.cli import cli  # noqa: E402
-
-if "ref" not in cli.commands:
-    cli.add_command(ref)

--- a/followthemoney/cli/ref.py
+++ b/followthemoney/cli/ref.py
@@ -21,7 +21,12 @@ from followthemoney.types.common import EnumType
 from followthemoney.schema import Schema
 from followthemoney.property import Property
 from followthemoney.cli.cli import cli
-from followthemoney.cli.render import is_json_mode, emit_json, print_table
+from followthemoney.cli.render import (
+    is_json_mode,
+    emit_json,
+    print_markdown,
+    print_table,
+)
 
 JSON_OPTION = click.option(
     "--json", "json_flag", is_flag=True, default=False, help="Emit JSON output."
@@ -197,7 +202,7 @@ def ref_schema(ctx: click.Context, name: str, stubs: bool, json_flag: bool) -> N
 
     click.echo(f"{schema.name}  ({schema.label})")
     if schema.description:
-        click.echo(schema.description.strip())
+        print_markdown(schema.description.strip())
     click.echo("")
     click.echo(f"  matchable:    {'yes' if schema.matchable else 'no'}")
     click.echo(f"  extends:      {', '.join(extends) or '(none)'}")
@@ -256,7 +261,7 @@ def _type_detail(ctx: click.Context, name: str, json_flag: bool) -> None:
 
     click.echo(f"{type_.name}  ({type_.label})")
     if type_.docs:
-        click.echo(type_.docs)
+        print_markdown(type_.docs)
     click.echo("")
     click.echo(f"  matchable:  {'yes' if type_.matchable else 'no'}")
     click.echo(f"  pivot:      {'yes' if type_.pivot else 'no'}")
@@ -382,7 +387,7 @@ def ref_prop(ctx: click.Context, qname: str, json_flag: bool) -> None:
 
     click.echo(f"{prop.qname}  ({prop.label})")
     if prop.description:
-        click.echo(prop.description.strip())
+        print_markdown(prop.description.strip())
     click.echo("")
     click.echo(f"  type:       {prop.type.name}")
     click.echo(f"  matchable:  {'yes' if prop.matchable else 'no'}")

--- a/followthemoney/cli/ref.py
+++ b/followthemoney/cli/ref.py
@@ -1,0 +1,421 @@
+"""``ftm ref`` — offline, incremental exploration of the FtM model.
+
+This command group exists so a coding agent (or a human) can discover the
+schema/type model one small step at a time — what schemata exist, what
+properties a ``Person`` accepts, what a property's type is — without reading
+the YAML sources or dumping the entire ``model.json``. Unlike a bundled
+snapshot, it reads the live in-process ``model`` and ``registry``, so it always
+reflects the installed version of followthemoney.
+
+Every command renders a rich table on a terminal and machine-readable JSON when
+``--json`` is passed or stdout is piped (see ``followthemoney.cli.render``)."""
+
+import sys
+import click
+import difflib
+from typing import Any, Dict, List, Optional
+
+from followthemoney import model
+from followthemoney.types import registry
+from followthemoney.types.common import EnumType
+from followthemoney.schema import Schema
+from followthemoney.property import Property
+from followthemoney.cli.render import is_json_mode, emit_json, print_table
+
+JSON_OPTION = click.option(
+    "--json", "json_flag", is_flag=True, default=False, help="Emit JSON output."
+)
+
+
+def _json_mode(ctx: click.Context, json_flag: bool) -> bool:
+    """Resolve JSON mode, honouring ``--json`` on either the group or command.
+
+    ``--json`` may be supplied before the subcommand (``ftm ref --json type X``)
+    or after it (``ftm ref type X --json``). The group stashes its flag in
+    ``ctx.obj`` so subcommands can OR the two together."""
+    inherited = bool(ctx.obj) and bool(ctx.obj.get("json"))
+    return is_json_mode(json_flag or inherited)
+
+
+def _suggest(name: str, valid: List[str]) -> Optional[str]:
+    """Return the closest valid name to ``name``, or ``None`` if none is close."""
+    matches = difflib.get_close_matches(name, valid, n=1, cutoff=0.6)
+    return matches[0] if matches else None
+
+
+def _fail(message: str, suggestion: Optional[str] = None) -> None:
+    """Print a usage error (with an optional did-you-mean) and exit code 2."""
+    hint = f" Did you mean: {suggestion}?" if suggestion else ""
+    click.echo(f"error: {message}{hint}", err=True)
+    sys.exit(2)
+
+
+def _schema_flags(schema: Schema) -> str:
+    """Compact flag string for a schema row (abstract/hidden/edge/...)."""
+    flags = []
+    if schema.abstract:
+        flags.append("abstract")
+    if schema.hidden:
+        flags.append("hidden")
+    if schema.generated:
+        flags.append("generated")
+    if schema.edge:
+        flags.append("edge")
+    if schema.deprecated:
+        flags.append("deprecated")
+    return ", ".join(flags)
+
+
+def _prop_flags(prop: Property) -> str:
+    """Compact flag string for a property row (stub/hidden/deprecated)."""
+    flags = []
+    if prop.stub:
+        flags.append("stub")
+    if prop.hidden:
+        flags.append("hidden")
+    if prop.deprecated:
+        flags.append("deprecated")
+    return ", ".join(flags)
+
+
+def _prop_payload(prop: Property) -> Dict[str, Any]:
+    """JSON shape for a property within a schema listing: to_dict + origin."""
+    data: Dict[str, Any] = dict(prop.to_dict())
+    data["from_schema"] = prop.schema.name
+    return data
+
+
+@click.group("ref", invoke_without_command=True, help="Browse the FtM model offline.")
+@JSON_OPTION
+@click.pass_context
+def ref(ctx: click.Context, json_flag: bool) -> None:
+    """Show a model overview when invoked without a subcommand."""
+    ctx.ensure_object(dict)["json"] = json_flag
+    if ctx.invoked_subcommand is not None:
+        return
+    schemata = sorted(model.schemata.keys())
+    types = sorted(t.name for t in registry.types)
+    commands = [
+        ("schemata", "List all schemata."),
+        ("schema NAME", "Show one schema and all its properties."),
+        ("types [NAME]", "List property types, or detail one."),
+        ("type NAME", "Detail one property type (alias)."),
+        ("prop QNAME", "Show one property, e.g. Person:name."),
+    ]
+    if _json_mode(ctx, json_flag):
+        emit_json(
+            {
+                "schemata_count": len(schemata),
+                "types_count": len(types),
+                "commands": [{"command": c, "help": h} for c, h in commands],
+            }
+        )
+        return
+    click.echo(f"FtM model: {len(schemata)} schemata, {len(types)} property types\n")
+    rows = [[f"ftm ref {cmd}", help_] for cmd, help_ in commands]
+    print_table(rows, headers=["command", "description"], title="ftm ref")
+
+
+@ref.command("schemata", help="List all schemata in the model.")
+@click.option("--matchable", is_flag=True, help="Only matchable schemata.")
+@click.option(
+    "--abstract/--no-abstract", default=None, help="Filter by abstract flag."
+)
+@JSON_OPTION
+@click.pass_context
+def ref_schemata(
+    ctx: click.Context, matchable: bool, abstract: Optional[bool], json_flag: bool
+) -> None:
+    """List schemata with their key attributes."""
+    entries: List[Dict[str, Any]] = []
+    for name in sorted(model.schemata.keys()):
+        schema = model.schemata[name]
+        if matchable and not schema.matchable:
+            continue
+        if abstract is not None and schema.abstract != abstract:
+            continue
+        entries.append(
+            {
+                "name": name,
+                "label": schema.label,
+                "matchable": schema.matchable,
+                "abstract": schema.abstract,
+                "extends": sorted(s.name for s in schema.extends),
+                "description": (schema.description or "").strip(),
+            }
+        )
+
+    if _json_mode(ctx, json_flag):
+        emit_json(entries)
+        return
+    rows = [
+        [
+            e["name"],
+            "✓" if e["matchable"] else "",
+            _schema_flags(model.schemata[e["name"]]),
+            ", ".join(e["extends"]),
+            e["description"],
+        ]
+        for e in entries
+    ]
+    print_table(
+        rows,
+        headers=["schema", "matchable", "flags", "extends", "description"],
+        caption=f"{len(entries)} schema(s)",
+    )
+
+
+@ref.command("schema", help="Show one schema and all its (inherited) properties.")
+@click.argument("name")
+@click.option("--stubs", is_flag=True, help="Include stub (reverse-edge) properties.")
+@JSON_OPTION
+@click.pass_context
+def ref_schema(ctx: click.Context, name: str, stubs: bool, json_flag: bool) -> None:
+    """Show a schema's metadata plus the full property set (own + inherited)."""
+    schema = model.get(name)
+    if schema is None:
+        _fail(
+            f"Unknown schema {name!r}.",
+            _suggest(name, list(model.schemata.keys())),
+        )
+        return
+
+    props = [p for p in schema.sorted_properties if stubs or not p.stub]
+    summary: Dict[str, Any] = {
+        "name": schema.name,
+        "label": schema.label,
+        "description": (schema.description or "").strip(),
+        "matchable": schema.matchable,
+        "abstract": schema.abstract,
+        "hidden": schema.hidden,
+        "generated": schema.generated,
+        "deprecated": schema.deprecated,
+        # All ancestors (transitive), not just direct parents.
+        "extends": sorted(s.name for s in schema.schemata if s != schema),
+        "descendants": sorted(s.name for s in schema.descendants),
+        "featured": list(schema.featured),
+        "required": list(schema.required),
+        "properties": [_prop_payload(p) for p in props],
+    }
+
+    if _json_mode(ctx, json_flag):
+        emit_json(summary)
+        return
+
+    click.echo(f"{schema.name}  ({schema.label})")
+    if summary["description"]:
+        click.echo(summary["description"])
+    click.echo("")
+    click.echo(f"  matchable:    {'yes' if schema.matchable else 'no'}")
+    click.echo(f"  extends:      {', '.join(summary['extends']) or '(none)'}")
+    click.echo(f"  featured:     {', '.join(summary['featured']) or '(none)'}")
+    click.echo(f"  required:     {', '.join(summary['required']) or '(none)'}")
+    click.echo("")
+    rows = [
+        [
+            p.name,
+            p.type.name,
+            "✓" if p.matchable else "",
+            _prop_flags(p),
+            p.schema.name,
+            (p.description or "").strip(),
+        ]
+        for p in props
+    ]
+    print_table(
+        rows,
+        headers=["property", "type", "matchable", "flags", "schema", "description"],
+        caption=f"{len(props)} property/properties (own + inherited)",
+    )
+
+
+def _type_detail(ctx: click.Context, name: str, json_flag: bool) -> None:
+    """Render the detail view for a single property type."""
+    try:
+        type_ = registry.get(name)
+    except AttributeError:
+        type_ = None
+    if type_ is None:
+        _fail(
+            f"Unknown type {name!r}.",
+            _suggest(name, [t.name for t in registry.types]),
+        )
+        return
+
+    using = sorted(
+        (
+            {"qname": p.qname, "schema": p.schema.name, "name": p.name}
+            for p in model.properties
+            if p.type == type_
+        ),
+        key=lambda p: p["qname"],
+    )
+    data: Dict[str, Any] = dict(type_.to_dict())
+    data["name"] = type_.name
+    data["properties"] = using
+
+    if _json_mode(ctx, json_flag):
+        emit_json(data)
+        return
+
+    click.echo(f"{type_.name}  ({type_.label})")
+    if type_.docs:
+        click.echo(type_.docs)
+    click.echo("")
+    click.echo(f"  matchable:  {'yes' if type_.matchable else 'no'}")
+    click.echo(f"  pivot:      {'yes' if type_.pivot else 'no'}")
+    click.echo(f"  group:      {type_.group or '(none)'}")
+    click.echo("")
+
+    if isinstance(type_, EnumType):
+        values = type_.names
+        rows = [[code, label] for code, label in sorted(values.items())]
+        print_table(
+            rows, headers=["value", "label"], caption=f"{len(values)} enum value(s)"
+        )
+        click.echo("")
+
+    prop_rows = [[p["qname"], p["schema"]] for p in using]
+    print_table(
+        prop_rows,
+        headers=["property", "schema"],
+        caption=f"{len(using)} property/properties of type {type_.name!r}",
+    )
+
+
+@ref.command("types", help="List property types, or detail one with [NAME].")
+@click.argument("name", required=False)
+@JSON_OPTION
+@click.pass_context
+def ref_types(ctx: click.Context, name: Optional[str], json_flag: bool) -> None:
+    """List all property types, or show one type's detail when NAME is given."""
+    if name is not None:
+        _type_detail(ctx, name, json_flag)
+        return
+
+    entries: List[Dict[str, Any]] = []
+    for type_ in sorted(registry.types, key=lambda t: t.name):
+        values = type_.names if isinstance(type_, EnumType) else {}
+        entry: Dict[str, Any] = {
+            "name": type_.name,
+            "label": type_.label,
+            "matchable": type_.matchable,
+            "pivot": type_.pivot,
+            "group": type_.group,
+            "values_count": len(values),
+        }
+        # Elide enum values from the index unless there are few enough to scan.
+        if 0 < len(values) <= 5:
+            entry["values"] = dict(values)
+        entries.append(entry)
+
+    if _json_mode(ctx, json_flag):
+        emit_json(entries)
+        return
+    rows = []
+    for e in entries:
+        if "values" in e:
+            values_cell = ", ".join(sorted(e["values"].keys()))
+        elif e["values_count"]:
+            values_cell = f"{e['values_count']} values"
+        else:
+            values_cell = ""
+        rows.append(
+            [
+                e["name"],
+                e["group"] or "",
+                "✓" if e["matchable"] else "",
+                "✓" if e["pivot"] else "",
+                values_cell,
+            ]
+        )
+    print_table(
+        rows,
+        headers=["type", "group", "matchable", "pivot", "values"],
+        caption=f"{len(entries)} type(s)",
+    )
+
+
+@ref.command("type", help="Detail one property type (alias for `types NAME`).")
+@click.argument("name")
+@JSON_OPTION
+@click.pass_context
+def ref_type(ctx: click.Context, name: str, json_flag: bool) -> None:
+    """Show one property type's detail; alias of ``ref types NAME``."""
+    _type_detail(ctx, name, json_flag)
+
+
+@ref.command("prop", help="Show one property by qualified name, e.g. Person:name.")
+@click.argument("qname")
+@JSON_OPTION
+@click.pass_context
+def ref_prop(ctx: click.Context, qname: str, json_flag: bool) -> None:
+    """Show a single property's full definition."""
+    if ":" not in qname:
+        _fail(f"Property name must be qualified as Schema:prop; got {qname!r}.")
+        return
+    # Resolve via the schema's property set rather than the qname index, so an
+    # inherited property addressed on a child schema (`Person:name`, where the
+    # canonical qname is `Thing:name`) still resolves to the defining property.
+    schema_name, _, prop_name = qname.partition(":")
+    schema = model.get(schema_name)
+    if schema is None:
+        _fail(
+            f"Unknown schema {schema_name!r} in {qname!r}.",
+            _suggest(schema_name, list(model.schemata.keys())),
+        )
+        return
+    prop = schema.get(prop_name)
+    if prop is None:
+        _fail(
+            f"Schema {schema_name!r} has no property {prop_name!r}.",
+            _suggest(prop_name, list(schema.properties.keys())),
+        )
+        return
+
+    schemata = sorted(s.name for s in model if s.get(prop.name) == prop)
+    data: Dict[str, Any] = dict(prop.to_dict())
+    data["schemata"] = schemata
+    if isinstance(prop.type, EnumType):
+        data["values"] = dict(prop.type.names)
+
+    if _json_mode(ctx, json_flag):
+        emit_json(data)
+        return
+
+    click.echo(f"{prop.qname}  ({prop.label})")
+    if prop.description:
+        click.echo(prop.description.strip())
+    click.echo("")
+    click.echo(f"  type:       {prop.type.name}")
+    click.echo(f"  matchable:  {'yes' if prop.matchable else 'no'}")
+    if prop.range is not None:
+        click.echo(f"  range:      {prop.range.name}")
+    if prop.reverse is not None:
+        click.echo(f"  reverse:    {prop.reverse.qname}")
+    if prop.format is not None:
+        click.echo(f"  format:     {prop.format}")
+    click.echo(f"  maxLength:  {prop.max_length}")
+    if prop.stub:
+        click.echo("  stub:       yes (reverse edge, not writable)")
+    if prop.deprecated:
+        click.echo("  deprecated: yes")
+    if prop.examples:
+        click.echo(f"  examples:   {', '.join(prop.examples)}")
+    click.echo(f"  schemata:   {', '.join(schemata)}")
+    if isinstance(prop.type, EnumType):
+        click.echo("")
+        rows = [[code, label] for code, label in sorted(prop.type.names.items())]
+        print_table(
+            rows,
+            headers=["value", "label"],
+            caption=f"{len(prop.type.names)} value(s) for type {prop.type.name!r}",
+        )
+
+
+# Attach to the root CLI group so `ftm ref ...` works whether the command is
+# loaded via the entry point or by importing this module directly (tests).
+from followthemoney.cli.cli import cli  # noqa: E402
+
+if "ref" not in cli.commands:
+    cli.add_command(ref)

--- a/followthemoney/cli/ref.py
+++ b/followthemoney/cli/ref.py
@@ -105,8 +105,11 @@ def ref(ctx: click.Context, json_flag: bool) -> None:
         ("schemata", "List all schemata."),
         ("schema NAME", "Show one schema and all its properties."),
         ("types [NAME]", "List property types, or detail one."),
-        ("type NAME", "Detail one property type (alias)."),
-        ("prop QNAME", "Show one property, e.g. Person:name."),
+        (
+            "type NAME",
+            "Detail one property type: possible values, and which properties use it.",
+        ),
+        ("prop QNAME", "Show property details, e.g. Person:name."),
     ]
     if _json_mode(ctx, json_flag):
         emit_json(
@@ -124,9 +127,7 @@ def ref(ctx: click.Context, json_flag: bool) -> None:
 
 @ref.command("schemata", help="List all schemata in the model.")
 @click.option("--matchable", is_flag=True, help="Only matchable schemata.")
-@click.option(
-    "--abstract/--no-abstract", default=None, help="Filter by abstract flag."
-)
+@click.option("--abstract/--no-abstract", default=None, help="Filter by abstract flag.")
 @JSON_OPTION
 @click.pass_context
 def ref_schemata(
@@ -146,7 +147,8 @@ def ref_schemata(
                 "label": schema.label,
                 "matchable": schema.matchable,
                 "abstract": schema.abstract,
-                "extends": sorted(s.name for s in schema.extends),
+                # All ancestors (transitive), not just direct parents.
+                "extends": sorted(s.name for s in schema.schemata if s != schema),
                 "description": (schema.description or "").strip(),
             }
         )
@@ -281,7 +283,9 @@ def _type_detail(ctx: click.Context, name: str, json_flag: bool) -> None:
         values = type_.names
         rows = [[code, label] for code, label in sorted(values.items())]
         print_table(
-            rows, headers=["value", "label"], caption=f"{len(values)} supported value(s)"
+            rows,
+            headers=["value", "label"],
+            caption=f"{len(values)} supported value(s)",
         )
 
 

--- a/followthemoney/cli/render.py
+++ b/followthemoney/cli/render.py
@@ -1,0 +1,48 @@
+"""Shared output helpers for CLI commands that present model metadata.
+
+These back the ``ftm ref`` command group, which has two audiences: a human at
+a terminal who wants a scannable table, and a coding agent (or ``jq``) that
+wants machine-readable JSON. Reach for these instead of hand-rolling output so
+every ``ref`` subcommand decides JSON-vs-table the same way."""
+
+import sys
+import orjson
+from typing import Any, List, Optional, Sequence
+
+from rich.console import Console
+from rich.table import Table
+
+
+def is_json_mode(json_flag: bool) -> bool:
+    """Decide whether to emit JSON rather than a table.
+
+    JSON wins when ``--json`` is passed explicitly, or whenever stdout is not a
+    terminal (piped or redirected) — so ``ftm ref schema Person | jq`` works
+    without the caller remembering the flag."""
+    return json_flag or not sys.stdout.isatty()
+
+
+def emit_json(data: Any) -> None:
+    """Write ``data`` to stdout as indented, key-sorted JSON with a newline."""
+    opt = orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS | orjson.OPT_APPEND_NEWLINE
+    sys.stdout.buffer.write(orjson.dumps(data, option=opt))
+
+
+def print_table(
+    rows: Sequence[Sequence[Any]],
+    headers: Sequence[str],
+    title: Optional[str] = None,
+    caption: Optional[str] = None,
+) -> None:
+    """Render ``rows`` as a rich table on stdout.
+
+    Used by the table (non-JSON) path of ``ref`` commands. ``caption`` is shown
+    below the table — a good place for a count or a clarifying footnote. Cell
+    values are stringified; ``None`` renders as an empty cell."""
+    table = Table(title=title, caption=caption, header_style="bold")
+    for header in headers:
+        table.add_column(header)
+    for row in rows:
+        cells: List[str] = ["" if c is None else str(c) for c in row]
+        table.add_row(*cells)
+    Console().print(table)

--- a/followthemoney/cli/render.py
+++ b/followthemoney/cli/render.py
@@ -10,6 +10,7 @@ import orjson
 from typing import Any, List, Optional, Sequence
 
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.table import Table
 
 
@@ -26,6 +27,15 @@ def emit_json(data: Any) -> None:
     """Write ``data`` to stdout as indented, key-sorted JSON with a newline."""
     opt = orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS | orjson.OPT_APPEND_NEWLINE
     sys.stdout.buffer.write(orjson.dumps(data, option=opt))
+
+
+def print_markdown(text: str) -> None:
+    """Render a markdown description block to stdout.
+
+    Schema, property, and type descriptions are authored in markdown; use this
+    for the standalone description blocks in the `ref` detail views so emphasis,
+    code spans, and lists format on a terminal. JSON output keeps the raw text."""
+    Console().print(Markdown(text))
 
 
 def print_table(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "openpyxl >= 3.0.5, < 4.0.0",
     "orjson >= 3.10.0, < 4.0",
     "pydantic >=2.11.0, < 3.0.0",
+    "rich >= 13.0.0, < 15.0.0",
 ]
 
 [project.urls]
@@ -94,6 +95,7 @@ rdf = "followthemoney.cli.exports:export_rdf"
 gexf = "followthemoney.cli.exports:export_gexf"
 cypher = "followthemoney.cli.exports:export_cypher"
 statements = "followthemoney.cli.statement:entity_statements"
+ref = "followthemoney.cli.ref:ref"
 
 [tool.hatch.build.targets.sdist]
 only-include = ["followthemoney", "LICENSE", "README.md"]

--- a/tests/test_cli_ref.py
+++ b/tests/test_cli_ref.py
@@ -1,0 +1,121 @@
+import orjson
+from click.testing import CliRunner
+
+from followthemoney.cli.cli import cli
+
+# Importing the module registers the `ref` group on the root CLI.
+import followthemoney.cli.ref as refmod  # noqa: F401
+
+
+def _json(cli_runner: CliRunner, args: list[str]):
+    """Invoke a ref command in --json mode and parse the payload."""
+    result = cli_runner.invoke(cli, [*args, "--json"])
+    assert result.exit_code == 0, result.output
+    return orjson.loads(result.output_bytes)
+
+
+def test_ref_overview(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref"])
+    assert data["schemata_count"] > 50
+    assert data["types_count"] > 10
+    assert any(c["command"].startswith("schema") for c in data["commands"])
+
+
+def test_ref_schemata_list(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "schemata"])
+    names = {e["name"] for e in data}
+    assert "Person" in names
+    assert "Thing" in names
+
+
+def test_ref_schemata_matchable_filter(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "schemata", "--matchable"])
+    assert all(e["matchable"] for e in data)
+    assert "Person" in {e["name"] for e in data}
+
+
+def test_ref_schema_includes_inherited(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "schema", "Person"])
+    assert data["name"] == "Person"
+    # extends lists ALL ancestors, not just the direct parent.
+    assert "LegalEntity" in data["extends"]
+    assert "Thing" in data["extends"]
+    assert "Person" not in data["extends"]
+    prop_names = {p["name"] for p in data["properties"]}
+    # `name` is inherited from Thing; it must appear with its origin schema.
+    assert "name" in prop_names
+    name_prop = next(p for p in data["properties"] if p["name"] == "name")
+    assert name_prop["from_schema"] == "Thing"
+
+
+def test_ref_schema_hides_stubs_by_default(cli_runner: CliRunner) -> None:
+    default = _json(cli_runner, ["ref", "schema", "Person"])
+    with_stubs = _json(cli_runner, ["ref", "schema", "Person", "--stubs"])
+    assert not any(p.get("stub") for p in default["properties"])
+    assert len(with_stubs["properties"]) >= len(default["properties"])
+
+
+def test_ref_schema_unknown_suggests(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(cli, ["ref", "schema", "Persn"])
+    assert result.exit_code == 2
+    assert "Did you mean: Person?" in result.output
+
+
+def test_ref_types_list_elides_large_enums(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "types"])
+    by_name = {e["name"] for e in data}
+    assert "name" in by_name and "country" in by_name
+    country = next(e for e in data if e["name"] == "country")
+    # Large enums are counted but their values are omitted from the index.
+    assert country["values_count"] > 5
+    assert "values" not in country
+    gender = next(e for e in data if e["name"] == "gender")
+    assert gender["values_count"] <= 5
+    assert "values" in gender
+
+
+def test_ref_type_detail_has_values_and_props(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "types", "topic"])
+    assert data["name"] == "topic"
+    assert len(data["values"]) > 0
+    assert any(p["name"] == "topics" for p in data["properties"])
+
+
+def test_ref_type_singular_alias(cli_runner: CliRunner) -> None:
+    plural = _json(cli_runner, ["ref", "types", "gender"])
+    singular = _json(cli_runner, ["ref", "type", "gender"])
+    assert plural == singular
+
+
+def test_ref_prop_resolves_inherited(cli_runner: CliRunner) -> None:
+    # Addressed on Person, but the property is defined on Thing.
+    data = _json(cli_runner, ["ref", "prop", "Person:name"])
+    assert data["qname"] == "Thing:name"
+    assert "Person" in data["schemata"]
+
+
+def test_ref_prop_enum_values(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "prop", "Person:gender"])
+    assert data["type"] == "gender"
+    assert "male" in data["values"]
+
+
+def test_ref_json_flag_before_subcommand(cli_runner: CliRunner) -> None:
+    # `--json` on the group must reach the subcommand, not be swallowed.
+    result = cli_runner.invoke(cli, ["ref", "--json", "type", "country"])
+    assert result.exit_code == 0, result.output
+    data = orjson.loads(result.output_bytes)
+    assert data["name"] == "country"
+    assert len(data["values"]) > 5
+
+
+def test_ref_prop_unqualified_errors(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(cli, ["ref", "prop", "name"])
+    assert result.exit_code == 2
+    assert "qualified" in result.output
+
+
+def test_ref_prop_unknown_prop_suggests(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(cli, ["ref", "prop", "Person:nonsense"])
+    assert result.exit_code == 2
+    assert "no property" in result.output

--- a/tests/test_cli_ref.py
+++ b/tests/test_cli_ref.py
@@ -26,6 +26,10 @@ def test_ref_schemata_list(cli_runner: CliRunner) -> None:
     names = {e["name"] for e in data}
     assert "Person" in names
     assert "Thing" in names
+    # extends lists all ancestors, matching the schema detail view.
+    person = next(e for e in data if e["name"] == "Person")
+    assert "LegalEntity" in person["extends"]
+    assert "Thing" in person["extends"]
 
 
 def test_ref_schemata_matchable_filter(cli_runner: CliRunner) -> None:

--- a/tests/test_cli_ref.py
+++ b/tests/test_cli_ref.py
@@ -45,7 +45,7 @@ def test_ref_schema_includes_inherited(cli_runner: CliRunner) -> None:
     # `name` is inherited from Thing; it must appear with its origin schema.
     assert "name" in prop_names
     name_prop = next(p for p in data["properties"] if p["name"] == "name")
-    assert name_prop["from_schema"] == "Thing"
+    assert name_prop["schema"] == "Thing"
 
 
 def test_ref_schema_hides_stubs_by_default(cli_runner: CliRunner) -> None:
@@ -77,8 +77,13 @@ def test_ref_types_list_elides_large_enums(cli_runner: CliRunner) -> None:
 def test_ref_type_detail_has_values_and_props(cli_runner: CliRunner) -> None:
     data = _json(cli_runner, ["ref", "types", "topic"])
     assert data["name"] == "topic"
+    assert data["enum"] is True
     assert len(data["values"]) > 0
     assert any(p["name"] == "topics" for p in data["properties"])
+    # A non-enum type reports enum=false and carries no values.
+    name_type = _json(cli_runner, ["ref", "type", "name"])
+    assert name_type["enum"] is False
+    assert "values" not in name_type
 
 
 def test_ref_type_singular_alias(cli_runner: CliRunner) -> None:


### PR DESCRIPTION
## Summary

Adds `ftm ref`, an offline CLI command group for exploring the FtM schema/type model incrementally. It's built for coding agents (and humans) who want a single, specific answer — what properties a `Person` accepts, what type a property holds, what values an enum allows — without reading the schema YAML or piping a full `dump-model` through `jq`. It reads the model compiled into the installed package, so it's always in sync and needs no network or API key.

## Commands

| Command | Behaviour |
|---|---|
| `ftm ref` | Model overview + subcommand index |
| `ftm ref schemata` | List schemata (`--matchable`, `--abstract` filters) |
| `ftm ref schema NAME` | One schema + full inherited property set (`--stubs` to include reverse edges) |
| `ftm ref types [NAME]` / `ftm ref type NAME` | List property types, or detail one |
| `ftm ref prop QNAME` | One property, e.g. `Person:name` |

## Output

Every command renders a [rich](https://github.com/Textualize/rich) table on a terminal and JSON when piped or when `--json` is passed. `--json` is honored whether given on the group (`ftm ref --json type country`) or the subcommand. Unknown schema/type/property names produce a `Did you mean: …?` suggestion and exit 2.

Two niceties worth calling out:
- Inherited properties resolve against the schema you ask about: `ftm ref prop Person:name` works even though `name` is defined on `Thing` (canonical qname `Thing:name`).
- `ref schema NAME` lists the complete settable property set (own + inherited), excluding stub reverse-edge properties unless `--stubs` is passed.

## Changes

- New `followthemoney/cli/ref.py` and shared `followthemoney/cli/render.py` (JSON-vs-table decision, `emit_json`, rich `print_table`).
- Adds `rich` to dependencies and a `ref` entry point under `followthemoney.cli`.
- Documents the commands in the CLI reference (`docs/docs/cli.md`), plus a light styleguide pass on that page.

## Testing

- `tests/test_cli_ref.py` — 14 tests covering both output modes, filters, inherited-property resolution, enum eliding, and error/suggestion paths.
- Existing CLI suite still passes; `mypy --strict` and `ruff` clean.