### PR TITLE
Fix boolean in Person.properties.position.matchable.

### DIFF
--- a/followthemoney/schema/Person.yaml
+++ b/followthemoney/schema/Person.yaml
@@ -71,7 +71,7 @@ Person:
       type: date
     position:
       label: Position
-      matchable: fals
+      matchable: false
     biography:
       label: Biography
       description: A biographical narrative of the person.


### PR DESCRIPTION
Invalid boolean in the YAML schema for `Person`, which can breaks dependent software that have strict typing.