### PR TITLE
Slim `ftm ref` JSON output for agent context

### DIFF
--- a/followthemoney/cli/ref.py
+++ b/followthemoney/cli/ref.py
@@ -109,14 +109,17 @@ def _prop_flags(prop: Property) -> str:
 def _prop_payload(prop: Property) -> Dict[str, Any]:
     """Ultra-short property shape for the schema field index.
 
-    The schema view lists *what* fields a schema has — name and type — plus a
-    ``stub`` flag for the opt-in reverse edges (hidden/deprecated props are
-    filtered out upstream). For a property's description, range, reverse, or
-    origin schema, reach for ``ref prop Schema:name``; bundling all that here
-    made the payload unscannable."""
+    The schema view lists *what* fields a schema has — name and type. Stub
+    properties (reverse edges that can't be written to) carry the qualified name
+    of the forward property they reverse as ``reverse``, which both flags them
+    as stubs and says where the edge actually lives. For a property's
+    description, range, or origin schema, reach for ``ref prop Schema:name``."""
     data: Dict[str, Any] = {"name": prop.name, "type": prop.type.name}
     if prop.stub:
-        data["stub"] = True
+        if prop.reverse is not None:
+            data["reverse"] = prop.reverse.qname
+        else:
+            data["stub"] = True
     return data
 
 
@@ -205,10 +208,9 @@ def ref_schemata(
 
 @ref.command("schema", help="Show one schema and all its (inherited) properties.")
 @click.argument("name")
-@click.option("--stubs", is_flag=True, help="Include stub (reverse-edge) properties.")
 @JSON_OPTION
 @click.pass_context
-def ref_schema(ctx: click.Context, name: str, stubs: bool, json_flag: bool) -> None:
+def ref_schema(ctx: click.Context, name: str, json_flag: bool) -> None:
     """Show a schema's metadata plus the full property set (own + inherited)."""
     schema = model.get(name)
     if schema is None:
@@ -218,13 +220,11 @@ def ref_schema(ctx: click.Context, name: str, stubs: bool, json_flag: bool) -> N
         )
         return
 
-    # Hidden and deprecated properties are always skipped — they only add noise
-    # to a field list meant for constructing entities. Stubs (reverse edges) are
-    # opt-in via --stubs.
+    # Hidden and deprecated properties are skipped — they only add noise to a
+    # field list. Stubs (reverse edges) are kept: they show the relationships an
+    # entity participates in, carrying their forward qname as `reverse`.
     props = [
-        p
-        for p in schema.sorted_properties
-        if (stubs or not p.stub) and not p.hidden and not p.deprecated
+        p for p in schema.sorted_properties if not p.hidden and not p.deprecated
     ]
     # Start from the model's own serialization so new schema fields flow through
     # automatically; override the few views `ref` presents differently.

--- a/followthemoney/cli/ref.py
+++ b/followthemoney/cli/ref.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional
 
 from followthemoney import model
 from followthemoney.types import registry
-from followthemoney.types.common import EnumType
+from followthemoney.types.common import EnumType, PropertyType
 from followthemoney.schema import Schema
 from followthemoney.property import Property
 from followthemoney.cli.cli import cli
@@ -26,6 +26,7 @@ from followthemoney.cli.render import (
     emit_json,
     print_markdown,
     print_table,
+    slim,
 )
 
 JSON_OPTION = click.option(
@@ -41,6 +42,27 @@ def _json_mode(ctx: click.Context, json_flag: bool) -> bool:
     ``ctx.obj`` so subcommands can OR the two together."""
     inherited = bool(ctx.obj) and bool(ctx.obj.get("json"))
     return is_json_mode(json_flag or inherited)
+
+
+def _resolve_type(name: str) -> Optional[PropertyType]:
+    """Resolve a property type by its singular name or its plural group name.
+
+    Type detail commands take the singular type name (``country``), but the
+    plural group name (``countries``) is what most people reach for first and is
+    what appears as a property ``group`` in entity data — accept either."""
+    try:
+        return registry.get(name)
+    except AttributeError:
+        return registry.groups.get(name)
+
+
+def _type_names() -> List[str]:
+    """Names a type can be addressed by — singular type names plus plural groups.
+
+    Used to power did-you-mean suggestions so a typo of either form lands."""
+    names = [t.name for t in registry.types]
+    names.extend(registry.groups.keys())
+    return names
 
 
 def _suggest(name: str, valid: List[str]) -> Optional[str]:
@@ -85,9 +107,16 @@ def _prop_flags(prop: Property) -> str:
 
 
 def _prop_payload(prop: Property) -> Dict[str, Any]:
-    """JSON shape for a property within a schema listing: to_dict + origin schema."""
-    data: Dict[str, Any] = dict(prop.to_dict())
-    data["schema"] = prop.schema.name
+    """Ultra-short property shape for the schema field index.
+
+    The schema view lists *what* fields a schema has — name and type — plus a
+    ``stub`` flag for the opt-in reverse edges (hidden/deprecated props are
+    filtered out upstream). For a property's description, range, reverse, or
+    origin schema, reach for ``ref prop Schema:name``; bundling all that here
+    made the payload unscannable."""
+    data: Dict[str, Any] = {"name": prop.name, "type": prop.type.name}
+    if prop.stub:
+        data["stub"] = True
     return data
 
 
@@ -109,6 +138,7 @@ def ref(ctx: click.Context, json_flag: bool) -> None:
             "type NAME",
             "Detail one property type: possible values, and which properties use it.",
         ),
+        ("type-values NAME", "List the value codes of an enum type, e.g. country."),
         ("prop QNAME", "Show property details, e.g. Person:name."),
     ]
     if _json_mode(ctx, json_flag):
@@ -154,7 +184,7 @@ def ref_schemata(
         )
 
     if _json_mode(ctx, json_flag):
-        emit_json(entries)
+        emit_json(slim(entries))
         return
     rows = [
         [
@@ -188,18 +218,34 @@ def ref_schema(ctx: click.Context, name: str, stubs: bool, json_flag: bool) -> N
         )
         return
 
-    props = [p for p in schema.sorted_properties if stubs or not p.stub]
+    # Hidden and deprecated properties are always skipped — they only add noise
+    # to a field list meant for constructing entities. Stubs (reverse edges) are
+    # opt-in via --stubs.
+    props = [
+        p
+        for p in schema.sorted_properties
+        if (stubs or not p.stub) and not p.hidden and not p.deprecated
+    ]
     # Start from the model's own serialization so new schema fields flow through
     # automatically; override the few views `ref` presents differently.
     extends = sorted(s.name for s in schema.schemata if s != schema)
     summary: Dict[str, Any] = dict(schema.to_dict())
     summary["name"] = schema.name
     summary["extends"] = extends  # all ancestors, not just direct parents
-    summary["descendants"] = sorted(s.name for s in schema.descendants)
+    # Trim noise from the field-list payload an agent reads to construct an
+    # entity: `schemata` (self + ancestors) restates name + extends; `caption`
+    # and `required` list prop subsets; `temporalExtent` is display metadata.
+    # `descendants` is no longer injected. All remain reachable on the schema.
+    for key in ("schemata", "caption", "required", "temporalExtent"):
+        summary.pop(key, None)
+    # Collapse the edge spec (source/target/label/...) to a plain boolean — that
+    # a schema is an edge is the signal; the wiring lives on the schema itself.
+    if "edge" in summary:
+        summary["edge"] = True
     summary["properties"] = [_prop_payload(p) for p in props]
 
     if _json_mode(ctx, json_flag):
-        emit_json(summary)
+        emit_json(slim(summary))
         return
 
     click.echo(f"{schema.name}  ({schema.label})")
@@ -256,9 +302,14 @@ def _type_detail(ctx: click.Context, name: str, json_flag: bool) -> None:
     data["name"] = type_.name
     data["enum"] = is_enum
     data["properties"] = using
+    # Enum value sets run to hundreds of entries; report the count and point at
+    # `ref type-values NAME` rather than inlining and burying everything else.
+    values = data.pop("values", {})
+    if is_enum:
+        data["values_count"] = len(values)
 
     if _json_mode(ctx, json_flag):
-        emit_json(data)
+        emit_json(slim(data))
         return
 
     click.echo(f"{type_.name}  ({type_.label})")
@@ -278,14 +329,10 @@ def _type_detail(ctx: click.Context, name: str, json_flag: bool) -> None:
         caption=f"{len(using)} property/properties of type {type_.name!r}",
     )
 
-    if isinstance(type_, EnumType):
+    if is_enum:
         click.echo("")
-        values = type_.names
-        rows = [[code, label] for code, label in sorted(values.items())]
-        print_table(
-            rows,
-            headers=["value", "label"],
-            caption=f"{len(values)} supported value(s)",
+        click.echo(
+            f"  {len(values)} values — see: ftm ref type-values {type_.name}"
         )
 
 
@@ -316,7 +363,7 @@ def ref_types(ctx: click.Context, name: Optional[str], json_flag: bool) -> None:
         entries.append(entry)
 
     if _json_mode(ctx, json_flag):
-        emit_json(entries)
+        emit_json(slim(entries))
         return
     rows = []
     for e in entries:
@@ -351,6 +398,50 @@ def ref_type(ctx: click.Context, name: str, json_flag: bool) -> None:
     _type_detail(ctx, name, json_flag)
 
 
+def _type_values(ctx: click.Context, name: str, json_flag: bool) -> None:
+    """Render only the value set of an enumerated type.
+
+    Pulled out of the type/prop detail views because enums like ``country`` have
+    hundreds of values — dumping them inline buries everything else. This is the
+    one place to ask "what are the legal codes for this field?". NAME may be the
+    singular type name or the plural group (``country`` or ``countries``)."""
+    type_ = _resolve_type(name)
+    if type_ is None:
+        _fail(f"Unknown type {name!r}.", _suggest(name, _type_names()))
+        return
+    if not isinstance(type_, EnumType):
+        _fail(f"Type {type_.name!r} is not enumerated; it has no fixed value set.")
+        return
+
+    values = type_.names
+    if _json_mode(ctx, json_flag):
+        emit_json(dict(values))
+        return
+
+    click.echo(f"{type_.name}  ({type_.label})")
+    click.echo("")
+    rows = [[code, label] for code, label in sorted(values.items())]
+    print_table(rows, headers=["value", "label"], caption=f"{len(values)} value(s)")
+
+
+@ref.command("type-values", help="List the value codes of an enum type, e.g. country.")
+@click.argument("name")
+@JSON_OPTION
+@click.pass_context
+def ref_type_values(ctx: click.Context, name: str, json_flag: bool) -> None:
+    """List the legal value codes (and labels) of an enumerated property type."""
+    _type_values(ctx, name, json_flag)
+
+
+@ref.command("types-values", help="Alias of `type-values`.")
+@click.argument("name")
+@JSON_OPTION
+@click.pass_context
+def ref_types_values(ctx: click.Context, name: str, json_flag: bool) -> None:
+    """List the legal value codes of an enum type; alias of ``ref type-values``."""
+    _type_values(ctx, name, json_flag)
+
+
 @ref.command("prop", help="Show one property by qualified name, e.g. Person:name.")
 @click.argument("qname")
 @JSON_OPTION
@@ -382,11 +473,13 @@ def ref_prop(ctx: click.Context, qname: str, json_flag: bool) -> None:
     schemata = sorted(s.name for s in model if s.get(prop.name) == prop)
     data: Dict[str, Any] = dict(prop.to_dict())
     data["schemata"] = schemata
+    # For enum-typed props, report the value count and defer the full set to
+    # `ref type-values NAME` instead of inlining hundreds of codes here.
     if isinstance(prop.type, EnumType):
-        data["values"] = dict(prop.type.names)
+        data["values_count"] = len(prop.type.names)
 
     if _json_mode(ctx, json_flag):
-        emit_json(data)
+        emit_json(slim(data))
         return
 
     click.echo(f"{prop.qname}  ({prop.label})")
@@ -410,10 +503,5 @@ def ref_prop(ctx: click.Context, qname: str, json_flag: bool) -> None:
         click.echo(f"  examples:   {', '.join(prop.examples)}")
     click.echo(f"  schemata:   {', '.join(schemata)}")
     if isinstance(prop.type, EnumType):
-        click.echo("")
-        rows = [[code, label] for code, label in sorted(prop.type.names.items())]
-        print_table(
-            rows,
-            headers=["value", "label"],
-            caption=f"{len(prop.type.names)} value(s) for type {prop.type.name!r}",
-        )
+        count = len(prop.type.names)
+        click.echo(f"  values:     {count} — see: ftm ref type-values {prop.type.name}")

--- a/followthemoney/cli/render.py
+++ b/followthemoney/cli/render.py
@@ -29,6 +29,46 @@ def emit_json(data: Any) -> None:
     sys.stdout.buffer.write(orjson.dumps(data, option=opt))
 
 
+#: Keys stripped from ``ref`` JSON regardless of value — storage and display
+#: details (``maxLength``, ``plural``) and the ``pivot`` flag that an agent
+#: reading the model to construct entities never needs.
+BLANKET_DROP_KEYS = frozenset({"maxLength", "plural", "pivot"})
+
+#: Keys stripped from ``ref`` JSON only when their value is ``False`` — a flag
+#: at its default carries no information, but the ``True`` case is signal.
+#: Targeted (not "every false boolean") so the rule never surprises us by
+#: swallowing a future flag whose ``False`` case matters.
+FALSE_DROP_KEYS = frozenset({"matchable", "abstract", "enum"})
+
+
+def slim(data: Any) -> Any:
+    """Recursively strip low-signal keys from a model payload before JSON output.
+
+    The ``ref`` JSON exists mainly as context for a coding agent; flags at their
+    default and storage trivia cost tokens without informing entity construction.
+    Recurses so the per-property lists nested inside a schema payload are trimmed
+    too. See ``BLANKET_DROP_KEYS`` and ``FALSE_DROP_KEYS`` for what goes; also
+    drops a ``label`` that merely echoes ``name`` (e.g. schema ``Person``)."""
+    if isinstance(data, dict):
+        # A label identical to the name adds no information over the name alone.
+        drop_label = (
+            "name" in data and "label" in data and data["label"] == data["name"]
+        )
+        out = {}
+        for key, value in data.items():
+            if key in BLANKET_DROP_KEYS:
+                continue
+            if key in FALSE_DROP_KEYS and value is False:
+                continue
+            if key == "label" and drop_label:
+                continue
+            out[key] = slim(value)
+        return out
+    if isinstance(data, list):
+        return [slim(item) for item in data]
+    return data
+
+
 def print_markdown(text: str) -> None:
     """Render a markdown description block to stdout.
 

--- a/tests/test_cli_ref.py
+++ b/tests/test_cli_ref.py
@@ -55,11 +55,14 @@ def test_ref_schema_includes_inherited(cli_runner: CliRunner) -> None:
     assert "qname" not in name_prop and "schema" not in name_prop
 
 
-def test_ref_schema_hides_stubs_by_default(cli_runner: CliRunner) -> None:
-    default = _json(cli_runner, ["ref", "schema", "Person"])
-    with_stubs = _json(cli_runner, ["ref", "schema", "Person", "--stubs"])
-    assert not any(p.get("stub") for p in default["properties"])
-    assert len(with_stubs["properties"]) >= len(default["properties"])
+def test_ref_schema_includes_stubs_with_reverse(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "schema", "Person"])
+    props = {p["name"]: p for p in data["properties"]}
+    # Stub (reverse-edge) properties are listed and carry the forward qname they
+    # reverse, rather than a bare stub flag.
+    owner = props["ownershipOwner"]
+    assert owner["reverse"] == "Ownership:owner"
+    assert "stub" not in owner
 
 
 def test_ref_schema_unknown_suggests(cli_runner: CliRunner) -> None:
@@ -170,8 +173,8 @@ def test_ref_schema_view_is_terse(cli_runner: CliRunner) -> None:
     for dropped in ("schemata", "caption", "descendants", "required", "temporalExtent"):
         assert dropped not in data
     assert "extends" in data and "featured" in data
-    # Properties are name + type only, plus a stub flag when set.
-    allowed = {"name", "type", "stub"}
+    # Properties are name + type only; stubs add a `reverse` qname.
+    allowed = {"name", "type", "reverse", "stub"}
     for prop in data["properties"]:
         assert set(prop).issubset(allowed)
         assert "name" in prop and "type" in prop

--- a/tests/test_cli_ref.py
+++ b/tests/test_cli_ref.py
@@ -46,10 +46,13 @@ def test_ref_schema_includes_inherited(cli_runner: CliRunner) -> None:
     assert "Thing" in data["extends"]
     assert "Person" not in data["extends"]
     prop_names = {p["name"] for p in data["properties"]}
-    # `name` is inherited from Thing; it must appear with its origin schema.
+    # Inherited props (e.g. `name` from Thing) are included in the field list.
     assert "name" in prop_names
+    # The schema view is an ultra-short index: name + type only, no qname/schema
+    # origin (those live in `ref prop`).
     name_prop = next(p for p in data["properties"] if p["name"] == "name")
-    assert name_prop["schema"] == "Thing"
+    assert name_prop["type"] == "name"
+    assert "qname" not in name_prop and "schema" not in name_prop
 
 
 def test_ref_schema_hides_stubs_by_default(cli_runner: CliRunner) -> None:
@@ -78,16 +81,20 @@ def test_ref_types_list_elides_large_enums(cli_runner: CliRunner) -> None:
     assert "values" in gender
 
 
-def test_ref_type_detail_has_values_and_props(cli_runner: CliRunner) -> None:
+def test_ref_type_detail_counts_values_and_lists_props(cli_runner: CliRunner) -> None:
     data = _json(cli_runner, ["ref", "types", "topic"])
     assert data["name"] == "topic"
     assert data["enum"] is True
-    assert len(data["values"]) > 0
+    # The detail view reports a count, not the inlined value set — the full set
+    # lives behind `ref type-values topic`.
+    assert data["values_count"] > 0
+    assert "values" not in data
     assert any(p["name"] == "topics" for p in data["properties"])
-    # A non-enum type reports enum=false and carries no values.
+    # A non-enum type drops the enum flag (false) and carries no values or count.
     name_type = _json(cli_runner, ["ref", "type", "name"])
-    assert name_type["enum"] is False
+    assert "enum" not in name_type
     assert "values" not in name_type
+    assert "values_count" not in name_type
 
 
 def test_ref_type_singular_alias(cli_runner: CliRunner) -> None:
@@ -106,7 +113,10 @@ def test_ref_prop_resolves_inherited(cli_runner: CliRunner) -> None:
 def test_ref_prop_enum_values(cli_runner: CliRunner) -> None:
     data = _json(cli_runner, ["ref", "prop", "Person:gender"])
     assert data["type"] == "gender"
-    assert "male" in data["values"]
+    # The full value set is deferred to `ref type-values gender`; here we only
+    # report how many there are.
+    assert data["values_count"] == 3
+    assert "values" not in data
 
 
 def test_ref_json_flag_before_subcommand(cli_runner: CliRunner) -> None:
@@ -115,7 +125,120 @@ def test_ref_json_flag_before_subcommand(cli_runner: CliRunner) -> None:
     assert result.exit_code == 0, result.output
     data = orjson.loads(result.output_bytes)
     assert data["name"] == "country"
-    assert len(data["values"]) > 5
+    assert data["values_count"] > 5
+
+
+def test_ref_type_values_singular_and_plural(cli_runner: CliRunner) -> None:
+    # The command resolves the singular type name and the plural group name.
+    singular = _json(cli_runner, ["ref", "type-values", "country"])
+    plural = _json(cli_runner, ["ref", "type-values", "countries"])
+    assert singular == plural
+    assert singular["de"] == "Germany"
+    assert len(singular) > 200
+
+
+def test_ref_types_values_alias(cli_runner: CliRunner) -> None:
+    via_type = _json(cli_runner, ["ref", "type-values", "gender"])
+    via_types = _json(cli_runner, ["ref", "types-values", "gender"])
+    assert via_type == via_types == {"male": "male", "female": "female", "other": "other"}
+
+
+def test_ref_type_values_non_enum_errors(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(cli, ["ref", "type-values", "name"])
+    assert result.exit_code == 2
+    assert "not enumerated" in result.output
+
+
+def test_ref_type_values_unknown_suggests(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(cli, ["ref", "type-values", "contry"])
+    assert result.exit_code == 2
+    assert "Did you mean: country?" in result.output
+
+
+def test_ref_slim_drops_storage_and_display_keys(cli_runner: CliRunner) -> None:
+    schema = _json(cli_runner, ["ref", "schema", "Person"])
+    assert "plural" not in schema
+    # maxLength is stripped at every depth, including nested property dicts.
+    assert all("maxLength" not in p for p in schema["properties"])
+    type_ = _json(cli_runner, ["ref", "type", "country"])
+    assert "maxLength" not in type_ and "plural" not in type_
+
+
+def test_ref_schema_view_is_terse(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "schema", "Person"])
+    # Top-level noise is trimmed; navigable fields stay.
+    for dropped in ("schemata", "caption", "descendants", "required", "temporalExtent"):
+        assert dropped not in data
+    assert "extends" in data and "featured" in data
+    # Properties are name + type only, plus a stub flag when set.
+    allowed = {"name", "type", "stub"}
+    for prop in data["properties"]:
+        assert set(prop).issubset(allowed)
+        assert "name" in prop and "type" in prop
+
+
+def test_ref_schema_skips_hidden_and_deprecated(cli_runner: CliRunner) -> None:
+    # Hidden and deprecated properties never appear in the schema field list.
+    from followthemoney import model
+
+    schema = model.get("Person")
+    assert schema is not None
+    listed = {p["name"] for p in _json(cli_runner, ["ref", "schema", "Person"])["properties"]}
+    for prop in schema.properties.values():
+        if prop.hidden or prop.deprecated:
+            assert prop.name not in listed
+
+
+def test_ref_schema_edge_is_boolean(cli_runner: CliRunner) -> None:
+    # Edge schemata collapse the edge spec to `edge: true`; non-edges omit it.
+    ownership = _json(cli_runner, ["ref", "schema", "Ownership"])
+    assert ownership["edge"] is True
+    person = _json(cli_runner, ["ref", "schema", "Person"])
+    assert "edge" not in person
+
+
+def test_ref_slim_drops_false_matchable_and_abstract(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "schemata"])
+    person = next(e for e in data if e["name"] == "Person")
+    # Person is matchable and concrete: matchable stays True, abstract is dropped.
+    assert person["matchable"] is True
+    assert "abstract" not in person
+    # A non-matchable schema drops the matchable key rather than showing false.
+    document = next(e for e in data if e["name"] == "Document")
+    assert "matchable" not in document
+
+
+def test_ref_slim_drops_false_enum(cli_runner: CliRunner) -> None:
+    # A non-enum type drops `enum` rather than reporting enum: false; the True
+    # case still shows on an enum type.
+    name_type = _json(cli_runner, ["ref", "type", "name"])
+    assert "enum" not in name_type
+    country = _json(cli_runner, ["ref", "type", "country"])
+    assert country["enum"] is True
+
+
+def test_ref_slim_drops_label_echoing_name(cli_runner: CliRunner) -> None:
+    # Person's label equals its name, so the top-level label is dropped.
+    person = _json(cli_runner, ["ref", "schema", "Person"])
+    assert person["name"] == "Person"
+    assert "label" not in person
+    # A label that differs from the name (Title Case) is kept — checked on the
+    # prop detail view, which still carries labels.
+    name_prop = _json(cli_runner, ["ref", "prop", "Person:name"])
+    assert name_prop["label"] == "Name"
+
+
+def test_ref_types_listing_drops_pivot(cli_runner: CliRunner) -> None:
+    data = _json(cli_runner, ["ref", "types"])
+    assert all("pivot" not in e for e in data)
+
+
+def test_ref_type_values_map_not_slimmed(cli_runner: CliRunner) -> None:
+    # Raw value maps are emitted verbatim — no key happens to collide, but the
+    # contract is that this command returns the unfiltered code->label mapping.
+    data = _json(cli_runner, ["ref", "type-values", "country"])
+    assert data["no"] == "Norway"
+    assert len(data) > 200
 
 
 def test_ref_prop_unqualified_errors(cli_runner: CliRunner) -> None:


### PR DESCRIPTION
Tightens the `ftm ref` JSON so it works well as context for a coding agent reading the FtM model, rather than dumping the full `to_dict()` shape. This is a deliberate breaking change to the v0 `ref` JSON, ~a week after it landed.

## Changes

**Split enum values into their own command**
- New `ftm ref type-values NAME` (and `types-values` alias). Accepts the singular type name or the plural group (`country` or `countries`); emits only the `code → label` mapping.
- `ref type` / `ref types` / `ref prop` no longer inline the value set — they report `values_count` and point at `type-values` (e.g. `country` was inlining 281 codes into both `ref type country` and `ref prop Person:nationality`).

**A `slim()` post-filter** (`render.py`), applied to all ref metadata JSON:
- Drop `maxLength`, `plural`, `pivot` (any value).
- Drop `matchable`, `abstract`, `enum` when `false` (targeted, so meaningful negatives elsewhere aren't swallowed).
- Drop a `label` that merely echoes `name`.

**Reshape the `ref schema` view** into a terse field index (command-specific, so `qname`/`label`/etc. still appear in `ref prop`):
- Properties become `{name, type}` (+ `stub` when set).
- Hidden and deprecated properties are skipped entirely.
- Top-level drops `schemata`, `caption`, `descendants`, `required`, `temporalExtent`; `edge` collapses to a boolean.

The raw `type-values` map is intentionally **not** slimmed.

## Tests

`tests/test_cli_ref.py` extended to cover the new command (singular/plural, non-enum error, did-you-mean), the slim rules, the schema-view reshape, hidden/deprecated skipping, and the boolean `edge`. Full suite green (296 passed); mypy --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)