### PR TITLE
Fix typo in Occupancy:constituency description (distict -> district)

### DIFF
--- a/followthemoney/schema/Occupancy.yaml
+++ b/followthemoney/schema/Occupancy.yaml
@@ -65,7 +65,7 @@ Occupancy:
     constituency:
       # https://www.popoloproject.com/specs/membership.html#classes-and-properties
       label: "Constituency"
-      description: "The geographic area/distict represented by the holder"
+      description: "The geographic area/district represented by the holder"
     politicalGroup:
       label: "Political group"
       description: "Caucus, faction or parliamentary group of the holder"

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -4578,7 +4578,7 @@
       "plural": "Occupancies",
       "properties": {
         "constituency": {
-          "description": "The geographic area/distict represented by the holder",
+          "description": "The geographic area/district represented by the holder",
           "label": "Constituency",
           "maxLength": 1024,
           "name": "constituency",

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -4578,7 +4578,7 @@
       "plural": "Occupancies",
       "properties": {
         "constituency": {
-          "description": "The geographic area/distict represented by the holder",
+          "description": "The geographic area/district represented by the holder",
           "label": "Constituency",
           "maxLength": 1024,
           "name": "constituency",


### PR DESCRIPTION
Fixes a small typo in the `Occupancy:constituency` property description: "distict" → "district". Regenerated `js/` and `java/` `defaultModel.json` via `make default-model`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
