### PR TITLE
js: expose ValueEntity metadata on Entity

### DIFF
--- a/js/src/entity.ts
+++ b/js/src/entity.ts
@@ -11,6 +11,12 @@ export interface IEntityDatum {
   schema: Schema | string
   properties?: EntityProperties
   id: string
+  caption?: string
+  datasets?: Array<string>
+  referents?: Array<string>
+  first_seen?: string
+  last_seen?: string
+  last_change?: string
 }
 
 /**
@@ -21,10 +27,22 @@ export class Entity {
   public id: string
   public properties: Map<Property, Values> = new Map()
   public readonly schema: Schema
+  public caption: string | null
+  public datasets: Array<string>
+  public referents: Array<string>
+  public first_seen: string | null
+  public last_seen: string | null
+  public last_change: string | null
 
   constructor(model: Model, data: IEntityDatum) {
     this.schema = model.getSchema(data.schema)
     this.id = data.id
+    this.caption = data.caption || null
+    this.datasets = data.datasets || []
+    this.referents = data.referents || []
+    this.first_seen = data.first_seen || null
+    this.last_seen = data.last_seen || null
+    this.last_change = data.last_change || null
 
     if (data.properties) {
       Object.entries(data.properties).forEach(([prop, values]) => {
@@ -111,9 +129,14 @@ export class Entity {
   }
 
   /**
-   * Get the designated label for the given entity.
+   * Get the designated label for the given entity. A caption computed
+   * upstream (e.g. by nomenklatura's name picker) takes precedence over
+   * deriving one from the schema's caption properties.
    */
   getCaption(): string {
+    if (this.caption !== null) {
+      return this.caption
+    }
     for (const property of this.schema.caption) {
       for (const value of this.getProperty(property)) {
         return value as string
@@ -126,6 +149,7 @@ export class Entity {
    * Set the designated label as the first caption prop for the given entity.
    */
   setCaption(value: string): void {
+    this.caption = value
     const captionProperties = this.schema.caption
     if (captionProperties && captionProperties.length > 0) {
       this.setProperty(captionProperties[0], value)
@@ -223,11 +247,30 @@ export class Entity {
         Entity.isEntity(value) ? (value as Entity).toJSON() : value
       )
     })
-    return {
+    const data: IEntityDatum = {
       id: this.id,
       schema: this.schema.name,
       properties: properties
     }
+    if (this.caption !== null) {
+      data.caption = this.caption
+    }
+    if (this.datasets.length > 0) {
+      data.datasets = this.datasets
+    }
+    if (this.referents.length > 0) {
+      data.referents = this.referents
+    }
+    if (this.first_seen !== null) {
+      data.first_seen = this.first_seen
+    }
+    if (this.last_seen !== null) {
+      data.last_seen = this.last_seen
+    }
+    if (this.last_change !== null) {
+      data.last_change = this.last_change
+    }
+    return data
   }
 
   /**

--- a/js/src/schema.ts
+++ b/js/src/schema.ts
@@ -7,7 +7,6 @@ interface IEdgeSpecification {
   directed: boolean
   label?: string
   caption: string[]
-  required?: string[]
 }
 
 interface ITemporalExtentSpecification {

--- a/js/test/entity.test.ts
+++ b/js/test/entity.test.ts
@@ -102,6 +102,66 @@ describe('ftm/Entity class', () => {
       expect(start!.property).toEqual(entity.schema.getProperty('startDate'))
       expect(start!.value).toEqual('2022-01-01')
     })
+    it('defaults entity metadata when absent', function() {
+      const fresh = model.getEntity(entityDatum)
+      expect(fresh.caption).toBeNull()
+      expect(fresh.datasets).toEqual([])
+      expect(fresh.referents).toEqual([])
+      expect(fresh.first_seen).toBeNull()
+      expect(fresh.last_seen).toBeNull()
+      expect(fresh.last_change).toBeNull()
+    })
+    it('does not emit absent metadata in toJSON', function() {
+      const fresh = model.getEntity(entityDatum)
+      expect(Object.keys(fresh.toJSON()).sort()).toEqual(
+        ['id', 'properties', 'schema']
+      )
+    })
+    it('parses and round-trips entity metadata', function() {
+      const datum = {
+        id: 'Q7747',
+        schema: 'Person',
+        caption: 'Vladimir Putin',
+        datasets: ['eu_fsf', 'us_ofac_sdn'],
+        referents: ['ofac-9914'],
+        first_seen: '2021-01-01T00:00:00',
+        last_seen: '2023-06-01T00:00:00',
+        last_change: '2022-03-14T00:00:00',
+        properties: {
+          name: ['Vladimir Vladimirovich PUTIN']
+        }
+      }
+      const fresh = model.getEntity(datum)
+      expect(fresh.caption).toBe('Vladimir Putin')
+      expect(fresh.datasets).toEqual(['eu_fsf', 'us_ofac_sdn'])
+      expect(fresh.referents).toEqual(['ofac-9914'])
+      expect(fresh.first_seen).toBe('2021-01-01T00:00:00')
+      expect(fresh.last_seen).toBe('2023-06-01T00:00:00')
+      expect(fresh.last_change).toBe('2022-03-14T00:00:00')
+      expect(fresh.toJSON()).toEqual(datum)
+      expect(fresh.clone().toJSON()).toEqual(datum)
+    })
+    it('prefers the precomputed caption', function() {
+      const fresh = model.getEntity({
+        id: 'Q7747',
+        schema: 'Person',
+        caption: 'Vladimir Putin',
+        properties: {
+          name: ['Vladimir Vladimirovich PUTIN']
+        }
+      })
+      expect(fresh.getCaption()).toBe('Vladimir Putin')
+    })
+    it('overrides the precomputed caption in setCaption', function() {
+      const fresh = model.getEntity({
+        id: 'Q7747',
+        schema: 'Person',
+        caption: 'Vladimir Putin'
+      })
+      fresh.setCaption('Wladimir Putin')
+      expect(fresh.getCaption()).toBe('Wladimir Putin')
+      expect(fresh.caption).toBe('Wladimir Putin')
+    })
     it('can get temporal end', function () {
       let entity
 


### PR DESCRIPTION
The JS `Entity` class only parsed `{id, schema, properties}` and dropped all entity-level metadata that the Python `ValueEntity` serialization emits — parsing a yente/OpenSanctions API entity and serializing it back lost provenance, and the upstream-picked display name was ignored in favour of recomputing a caption locally.

Changes:

- `IEntityDatum` and `Entity` gain the six `ValueEntity` fields: `caption`, `datasets`, `referents`, `first_seen`, `last_seen`, `last_change` (all optional; snake_case to match the wire format).
- `getCaption()` prefers the precomputed `caption` when present, matching `StatementEntity.caption` precedence in Python; `setCaption()` keeps the field in sync so it isn't masked by a stale value.
- `toJSON()` round-trips the new fields, emitting each only when set — output for plain `{id, schema, properties}` entities is unchanged, and `clone()` preserves the metadata.
- Drop the phantom `required` field from `IEdgeSpecification`; Python's `EdgeSpec` never had it.

This mirrors the shape of the fork carried in the opensanctions.org site (`site/lib/ftm/entity.ts`), so it can eventually be replaced by the upstream package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)