### PR TITLE
js: add IStatementDatum for the statement wire format

### DIFF
--- a/js/src/followthemoney.ts
+++ b/js/src/followthemoney.ts
@@ -3,6 +3,7 @@ export * from './model'
 export * from './namespace'
 export * from './property'
 export * from './schema'
+export * from './statement'
 export * from './type'
 export * from './icons'
 

--- a/js/src/statement.ts
+++ b/js/src/statement.ts
@@ -1,0 +1,27 @@
+
+/**
+ * A single statement about a property relevant to an entity: in dataset X,
+ * entity A had property P set to value V, observed between two timestamps.
+ *
+ * This mirrors the wire format of the Python `Statement.to_dict()`
+ * (`StatementDict`), which emits all keys with `null` for unset values.
+ * `prop_type` is not part of that serialization but is added by the
+ * OpenSanctions statement API and CSV exports, so it is accepted here
+ * as an optional extra.
+ */
+export interface IStatementDatum {
+  id?: string | null
+  entity_id: string
+  canonical_id: string
+  prop: string
+  prop_type?: string
+  schema: string
+  value: string
+  dataset: string
+  lang?: string | null
+  original_value?: string | null
+  external: boolean
+  first_seen?: string | null
+  last_seen?: string | null
+  origin?: string | null
+}

--- a/js/test/statement.test.ts
+++ b/js/test/statement.test.ts
@@ -1,0 +1,45 @@
+import { IStatementDatum } from '../src/followthemoney'
+
+// Shape emitted by Python Statement.to_dict(): all keys present,
+// null for unset optionals, no prop_type.
+const ftmStatement: IStatementDatum = {
+  canonical_id: 'Q7747',
+  entity_id: 'ofac-9914',
+  prop: 'name',
+  schema: 'Person',
+  value: 'Vladimir Vladimirovich PUTIN',
+  dataset: 'us_ofac_sdn',
+  lang: null,
+  original_value: null,
+  first_seen: '2021-01-01T00:00:00',
+  last_seen: '2023-06-01T00:00:00',
+  external: false,
+  origin: null,
+  id: '81cf3b47f28f8ac8d80cad84d558a17dcbe0973b'
+}
+
+// Shape returned by the OpenSanctions statement API, which adds
+// prop_type and omits null keys.
+const apiStatement: IStatementDatum = {
+  id: '81cf3b47f28f8ac8d80cad84d558a17dcbe0973b',
+  entity_id: 'ofac-9914',
+  canonical_id: 'Q7747',
+  prop: 'name',
+  prop_type: 'name',
+  schema: 'Person',
+  dataset: 'us_ofac_sdn',
+  value: 'Vladimir Vladimirovich PUTIN',
+  external: false,
+  first_seen: '2021-01-01T00:00:00',
+  last_seen: '2023-06-01T00:00:00'
+}
+
+describe('ftm/IStatementDatum', () => {
+  it('covers the Python statement wire format', function() {
+    expect(ftmStatement.canonical_id).toBe('Q7747')
+    expect(ftmStatement.prop_type).toBeUndefined()
+  })
+  it('covers the statement API response format', function() {
+    expect(apiStatement.prop_type).toBe('name')
+  })
+})


### PR DESCRIPTION
Adds an `IStatementDatum` interface to the JS bindings, mirroring the Python `StatementDict` wire format (`followthemoney/statement/statement.py`). The bindings previously had no statement type at all; the only TS definition in the stack was a local copy on the opensanctions.org site.

- All 13 `StatementDict` keys, with `?: ... | null` on the optionals so both the Python serialization (all keys present, `null` for unset) and API responses (null keys omitted) type-check.
- `prop_type` is included as optional: it is not part of `Statement.to_dict()`, but the OpenSanctions statement API and CSV/DB exports add it.
- Exported from the package root; a compile-level test pins the type against both wire shapes.

Type only — no `Statement` class and no ingestion of `statements: [...]` in `Entity` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)