### PR TITLE
Fix NumberType.parse silent corruption of common numeric shapes (#331)

### DIFF
--- a/followthemoney/types/number.py
+++ b/followthemoney/types/number.py
@@ -1,7 +1,30 @@
 import re
+from functools import cache
 
 from followthemoney.types.common import PropertyType
 from followthemoney.util import defer as _
+
+
+@cache
+def _number_pattern(decimal: str, separator: str) -> re.Pattern[str]:
+    """Build a strict, fully-anchored number+unit pattern for a given locale.
+
+    A separator (or whitespace) is only accepted as a thousands/lakh grouping
+    when it splits digits into valid groups; a lone run of digits is accepted
+    ungrouped. Anything the pattern cannot match end-to-end is rejected by the
+    caller rather than silently truncated (see issue #331)."""
+    dec = re.escape(decimal)
+    grp = rf"[{re.escape(separator)}\s]"
+    # Either grouped digits (western 3s, indian 2/3s) or a plain run of digits.
+    integer = rf"(?:\d{{1,3}}(?:{grp}\d{{2,3}})+|\d+)"
+    number = rf"[+-]?\s?{integer}(?:{dec}\d+)?"
+    # A unit is digit-free: any digit after the number may belong to a second,
+    # glued-on number (a compact range, scientific notation, or a repeated
+    # decimal/grouping char), which then fails the end-anchored match rather
+    # than being mistaken for a unit (see issue #331).
+    unit = r"[^\s\d]+"
+    pattern = rf"^\s*(?P<number>{number})\s*(?P<unit>{unit})?\s*$"
+    return re.compile(pattern, re.UNICODE)
 
 
 class NumberType(PropertyType):
@@ -16,10 +39,6 @@ class NumberType(PropertyType):
     SEPARATOR = ","
     PRECISION = 2
 
-    _NUM_UNIT_RE = (
-        f"(\\s?\\-?\\s?\\d+(?:{re.escape(DECIMAL)}\\d+)?)\\s*([^\\s\\d][^\\s]*)?"
-    )
-    NUM_UNIT_RE = re.compile(_NUM_UNIT_RE, re.UNICODE)
     _FLOAT_FMT = "{:" + SEPARATOR + "." + str(PRECISION) + "f}"
     _INT_FMT = "{:" + SEPARATOR + "d}"
 
@@ -46,23 +65,28 @@ class NumberType(PropertyType):
 
         Returns:
             A tuple of (number, unit), where number is a string and unit is a string or None.
+
+        Returns (None, None) when the string is not a single, well-formed number
+        with an optional unit. Ambiguous or multi-number inputs (e.g. ranges, or a
+        European decimal comma under the default separator) are rejected rather
+        than silently coerced into a structurally different value (see issue #331).
         """
-        value = value.replace(separator, "")
-        if decimal != self.DECIMAL:
-            value = value.replace(decimal, self.DECIMAL)
-        match = self.NUM_UNIT_RE.match(value)
-        if not match:
+        match = _number_pattern(decimal, separator).match(value.strip())
+        if match is None:
             return None, None
-        number, unit = match.groups()
+        unit = match.group("unit")
         if unit is not None:
             unit = unit.strip()
             if len(unit) == 0:
                 unit = None
         # TODO: We could have a lookup table for common units, e.g. kg, m, etc. to
         # convert them to a standard form.
-        number = number.replace(" ", "")
+        number = match.group("number").replace(separator, "")
+        number = re.sub(r"\s+", "", number)
+        if decimal != self.DECIMAL:
+            number = number.replace(decimal, self.DECIMAL)
         if number == "":
-            number = None
+            return None, None
         return number, unit
 
     def to_number(self, value: str) -> float | None:

--- a/tests/types/test_number.py
+++ b/tests/types/test_number.py
@@ -23,6 +23,99 @@ def test_parse_numbers():
     assert numbers.parse("42 °C") == ("42", "°C")
 
 
+def test_parse_numbers_no_silent_corruption():
+    # Regression tests for issue #331: parse must not silently return a
+    # structurally different number. Ambiguous or multi-number inputs should
+    # yield (None, None) so callers can warn, rather than a plausible-but-wrong
+    # value.
+
+    # Space-grouped thousands must not truncate at the first space.
+    assert numbers.parse("1 000 000") == ("1000000", None)
+
+    # A European decimal comma under the default separator=',' is an invalid
+    # thousands grouping (1-digit group) and must be rejected, not read as 15.
+    assert numbers.parse("1,5") == (None, None)
+
+    # Ranges must not collapse to the lower bound with '-' as the unit.
+    assert numbers.parse("5,000,000 - 10,000,000") == (None, None)
+
+    # European dot-grouping under the default decimal='.' is ambiguous and must
+    # not be truncated with a garbage unit.
+    assert numbers.parse("1.234.567") == (None, None)
+
+    # Trailing content that is not a recognizable unit must be rejected rather
+    # than the number silently taken from the head of the string.
+    assert numbers.parse("12 and 34") == (None, None)
+
+
+def test_parse_numbers_still_accepts_valid():
+    # Guard against the stricter parser over-rejecting legitimate inputs.
+
+    # Plain ungrouped integers of any length.
+    assert numbers.parse("1000000") == ("1000000", None)
+    assert numbers.parse("007") == ("007", None)
+
+    # Western thousands grouping, with and without a decimal part.
+    assert numbers.parse("1,000,000") == ("1000000", None)
+    assert numbers.parse("1,000,000.50") == ("1000000.50", None)
+
+    # Indian lakh/crore grouping.
+    assert numbers.parse("1,00,00,000") == ("10000000", None)
+
+    # Signs, including an explicit plus and a space after the sign.
+    assert numbers.parse("+42") == ("+42", None)
+    assert numbers.parse("- 999.0") == ("-999.0", None)
+
+    # Decimals.
+    assert numbers.parse("0.5") == ("0.5", None)
+
+    # Surrounding whitespace is ignored.
+    assert numbers.parse("  42  ") == ("42", None)
+
+    # A variety of trailing units (letters, symbols, percent, degrees).
+    assert numbers.parse("3.14 m") == ("3.14", "m")
+    assert numbers.parse("100%") == ("100", "%")
+    assert numbers.parse("10.5°C") == ("10.5", "°C")
+    assert numbers.parse("1,234.5 kg") == ("1234.5", "kg")
+
+
+def test_parse_numbers_rejects_digit_unit():
+    # These exercise the digit-in-unit guard specifically: the pattern DOES
+    # fully match, taking a leading number and a trailing "unit" that starts
+    # with a non-digit but carries digits (e.g. "1.234" + ".567"). Such a unit
+    # is really a second, glued-on number — a compact range, a repeated
+    # decimal/grouping char, scientific notation, or an expression — so we
+    # reject rather than return the head with a garbage unit.
+    assert numbers.parse("1.234.567") == (None, None)  # -> would be ("1.234", ".567")
+    assert numbers.parse("1,5") == (None, None)  # -> would be ("1", ",5")
+    assert numbers.parse("1e6") == (None, None)  # -> would be ("1", "e6")
+    assert numbers.parse("5-10") == (None, None)  # compact range
+    assert numbers.parse("10-20kg") == (None, None)  # compact range with unit
+    assert numbers.parse("3x4") == (None, None)
+    assert numbers.parse("2+2") == (None, None)
+
+    # A genuine unit with no digits is still accepted (the guard must not be
+    # over-broad). Note "²" is not an ASCII decimal digit, so it survives.
+    assert numbers.parse("5 m²") == ("5", "m²")
+    assert numbers.parse("42°C") == ("42", "°C")
+
+
+def test_parse_numbers_locale_config():
+    # The inputs the default config rejects as ambiguous must parse correctly
+    # once the caller supplies the right decimal/separator characters.
+    assert numbers.parse("1,5", decimal=",", separator=".") == ("1.5", None)
+    assert numbers.parse("1.234.567", decimal=",", separator=".") == (
+        "1234567",
+        None,
+    )
+    assert numbers.parse("1.234.567,89", decimal=",", separator=".") == (
+        "1234567.89",
+        None,
+    )
+    assert numbers.parse("1 234,56", decimal=",", separator=" ") == ("1234.56", None)
+    assert numbers.parse("1.234,5 kg", decimal=",", separator=".") == ("1234.5", "kg")
+
+
 def test_format_numbers():
     assert numbers.caption("100000") == "100,000"
     assert numbers.caption("-999.0") == "-999"


### PR DESCRIPTION
Fixes #331.

## Problem

`NumberType.parse` silently returned structurally different numbers for several common inputs. It stripped the configured separator unconditionally, used an anchored-but-not-full `re.match`, and treated any trailing token as a "unit":

```python
registry.number.parse("1 000 000")             # -> ('1', None)          space-grouped thousands truncated
registry.number.parse("1,5")                   # -> ('15', None)         European decimal -> 10x error
registry.number.parse("5,000,000 - 10,000,000")# -> ('5000000', '-')     range collapsed, '-' becomes unit
registry.number.parse("1.234.567")             # -> ('1.234', '.567')    dot-grouping truncated + garbage unit
```

Via zavod's `apply_number` (stored with `cleaned=True`) these land on entities with no warning. For a data-cleaning primitive, a plausible-but-wrong number is the worst failure mode.

## Fix

Rewrite `parse` around a single strict, fully-anchored pattern (built per locale, cached):

- **Require an end-to-end match** — leftover content is rejected, killing the range/second-number garbage-unit cases.
- **Validate grouping** — a separator (or whitespace) is accepted only when it splits digits into valid western (3s) or Indian (2/3s) groups; otherwise a plain ungrouped run of digits. Whitespace now counts as a group separator, so `"1 000 000"` parses.
- **Units are digit-free by construction** (`[^\s\d]+`) — a glued-on second number (compact range `5-10`, scientific notation `1e6`, repeated decimal char `1.234.567`) fails the match rather than being mistaken for a unit.

Ambiguous or multi-number inputs now return `(None, None)` so callers can warn. Correct results are still available when the caller passes the right `decimal`/`separator`:

```python
registry.number.parse("1,5", decimal=",", separator=".")   # -> ('1.5', None)
registry.number.parse("1 234,56", decimal=",", separator=" ")  # -> ('1234.56', None)
```

This touches only `parse` / `to_number` / `caption` — no entity IDs or checksums are affected.

## Behavior changes

| input | before | after |
|---|---|---|
| `"1 000 000"` | `('1', None)` | `('1000000', None)` |
| `"1,5"` | `('15', None)` | `(None, None)` |
| `"5,000,000 - 10,000,000"` | `('5000000', '-')` | `(None, None)` |
| `"1.234.567"` | `('1.234', '.567')` | `(None, None)` |

Existing cases (`"1,00,000"`, `"5 kg"`, `"42 °C"`, `"-100000.234tonnes"`, …) are unchanged.

## Tests

Added regression coverage in `tests/types/test_number.py`: the #331 repros, an over-rejection guard (legitimate forms still parse), the explicit-locale escape hatch, and the digit-in-unit rejection cases. Full suite (300 tests) and `mypy --strict` pass.

## Known trade-off

ASCII digit-bearing units like `"m2"` / `"m3"` are now rejected (write `"m²"`, or pass a numbers spec). Superscript `²`/`³` are unaffected (not ASCII decimal digits).

## Follow-up (separate, in zavod)

`apply_number` should log a warning when `parse` returns `None`, so dropped values are visible rather than silent. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)