### PR TITLE
Take the country for a phone number from format=

### DIFF
--- a/docs/explorer/types/phone.md
+++ b/docs/explorer/types/phone.md
@@ -1,7 +1,24 @@
 {% set type = select_type('phone') %}
 # {{ type.plural }}
 
-Phone numbers are normalised to the international E.164 format (think `+442083661177`). Since phone numbers are often provided by a source dataset without their country prefix, it is very helpful to supply the type validation functions (`phone.validate(value)` and `phone.clean(value)`) with an [proxy][followthemoney.proxy.EntityProxy] argument of the entity they will be assigned to, and from which country context can be inferred.
+Phone numbers are normalised to the international E.164 format (think `+442083661177`). Source datasets often give numbers in national format, without the country prefix. Such values cannot be interpreted on their own and are rejected, unless you name the country the number is dialed in via the `format` argument:
+
+```python
+from followthemoney import model
+from followthemoney.types import registry
+
+registry.phone.clean("020 8366 1177")               # None
+registry.phone.clean("020 8366 1177", format="gb")  # '+442083661177'
+
+entity = model.make_entity("Company")
+entity.add("phone", "020 8366 1177", format="gb")
+```
+
+The hint accepts any country code `rigour` recognises, including three-letter codes and subdivisions such as `gb-eng`, which resolve to the country they dial through. Territories without a dialing plan of their own (`eu`, historical states) raise an error, as does a code that cannot be resolved at all.
+
+!!! warning "Upgrading from 4.10 and earlier"
+
+    Earlier versions parsed national-format numbers using the country properties of the [proxy][followthemoney.proxy.EntityProxy] they were added to, which made the result depend on the order in which properties were added. The entity is not consulted: pass `format`, or such numbers are rejected.
 
 {% include 'templates/type.md' %}
 

--- a/followthemoney/proxy.py
+++ b/followthemoney/proxy.py
@@ -189,7 +189,9 @@ class EntityProxy:
         :param quiet: a reference to an non-existent property will return
             an empty list instead of raising an error.
         :param fuzzy: when normalising the data, should fuzzy matching be allowed.
-        :param format: when normalising the data, formatting for a date.
+        :param format: when normalising the data, a type-specific hint: a
+            `strptime` pattern for dates, or the country a phone number is
+            dialed in.
         """
         prop_name = self._prop_name(prop, quiet=quiet)
         if prop_name is None:

--- a/followthemoney/types/common.py
+++ b/followthemoney/types/common.py
@@ -108,10 +108,11 @@ class PropertyType:
 
         Returns `None` if the value is empty or cannot be interpreted as this type.
         The `fuzzy` flag loosens validation for types that support it (dates,
-        identifiers). `format` supplies a type-specific hint — for example, a
-        `strptime` format string for dates. `proxy` is the entity the value is
-        being added to, which some types use for context-aware cleaning (address
-        normalization can use the entity's country, for example).
+        identifiers). `format` supplies a type-specific hint — a `strptime` format
+        string for dates, or the country a phone number is dialed in. `proxy` is
+        the entity the value is being added to, which a few types use for
+        context-aware cleaning (an entity reference cannot point at itself, for
+        example).
 
         This method converts the input to a string, drops null-equivalents, and
         then delegates to `clean_text`. Subclasses normally override `clean_text`

--- a/followthemoney/types/phone.py
+++ b/followthemoney/types/phone.py
@@ -1,10 +1,18 @@
-from collections.abc import Iterable
+from functools import cache
 from typing import TYPE_CHECKING, Optional
 
-from phonenumbers import PhoneNumber, PhoneNumberFormat, format_number, is_valid_number
+from phonenumbers import (
+    SUPPORTED_REGIONS,
+    PhoneNumber,
+    PhoneNumberFormat,
+    format_number,
+    is_valid_number,
+)
 from phonenumbers import parse as parse_number
 from phonenumbers.phonenumberutil import NumberParseException, region_code_for_number
+from rigour.territories import get_territory
 
+from followthemoney.exc import InvalidData
 from followthemoney.types.common import PropertyType
 from followthemoney.util import dampen
 from followthemoney.util import defer as _
@@ -17,18 +25,41 @@ if TYPE_CHECKING:
 # https://stackoverflow.com/questions/6478875/regular-expression-matching-e-164-formatted-phone-numbers
 
 
-class PhoneType(PropertyType):
-    """A phone number in E.164 format. This means that phone numbers always
-    include an international country prefix (e.g. `+38760183628`). The
-    cleaning and validation functions for this try to be smart about by
-    accepting a list of countries as an argument in order to add the number
-    prefix.
+@cache
+def _dialing_region(country: str) -> str:
+    """Turn a country code into a region code that phone numbers can be dialed in.
 
-    When adding a property of this type to an entity, any country-type properties
-    defined for the entity are considered for validation. That means that adding a
-    phone number to an entity before adding a country can have a different
-    validation outcome from doing the two operations the other way around. Always
-    define the country first."""
+    Accepts anything `rigour` recognises as a territory, including subdivisions
+    like `gb-eng`, which resolve to their parent country. Territories that have
+    no dialing plan of their own (`eu`, `zz`, historical states) are rejected.
+    """
+    territory = get_territory(country)
+    if territory is not None:
+        for code in (territory.code, territory.ftm_country):
+            if code is not None and code.upper() in SUPPORTED_REGIONS:
+                return code.upper()
+    raise InvalidData(f"Not a valid country for a phone number: {country!r}")
+
+
+def _parse_valid(number: str, region: str | None) -> PhoneNumber | None:
+    """Parse a number as dialed in the given region, if it yields a valid number."""
+    try:
+        parsed = parse_number(number, region)
+    except NumberParseException:
+        return None
+    if not is_valid_number(parsed):
+        return None
+    return parsed
+
+
+class PhoneType(PropertyType):
+    """A phone number in E.164 format, i.e. one that always carries an
+    international dialing prefix (e.g. `+38760183628`).
+
+    Source data often gives numbers in national format, without that prefix. Pass
+    the country the number is dialed in as the `format` hint to have the prefix
+    applied, e.g. `entity.add("phone", "017623423980", format="de")`. A number
+    that is neither in international format nor accompanied by a hint is rejected."""
 
     name = "phone"
     group = "phones"
@@ -38,39 +69,6 @@ class PhoneType(PropertyType):
     pivot = True
     max_length = 64
 
-    def _clean_countries(
-        self, proxy: Optional["EntityProxy"]
-    ) -> Iterable[str | None]:
-        yield None
-        if proxy is not None:
-            for country in proxy.countries:
-                yield country.upper()
-
-    def _parse_number(
-        self, number: str, proxy: Optional["EntityProxy"] = None
-    ) -> Iterable[PhoneNumber]:
-        """Parse a phone number and return in international format.
-
-        If no valid phone number can be detected, None is returned. If
-        a country code is supplied, this will be used to infer the
-        prefix.
-
-        https://github.com/daviddrysdale/python-phonenumbers
-        """
-        for code in self._clean_countries(proxy):
-            try:
-                yield parse_number(number, code)
-            except NumberParseException:
-                pass
-
-    def validate(
-        self, value: str, fuzzy: bool = False, format: str | None = None
-    ) -> bool:
-        for num in self._parse_number(value):
-            if is_valid_number(num):
-                return True
-        return False
-
     def clean_text(
         self,
         text: str,
@@ -78,10 +76,15 @@ class PhoneType(PropertyType):
         format: str | None = None,
         proxy: Optional["EntityProxy"] = None,
     ) -> str | None:
-        for num in self._parse_number(text, proxy=proxy):
-            if is_valid_number(num):
-                return str(format_number(num, PhoneNumberFormat.E164))
-        return None
+        # Resolved up front so that an invalid hint is reported even when the
+        # number turns out to be in international format already:
+        region = None if format is None else _dialing_region(format)
+        parsed = _parse_valid(text, None)
+        if parsed is None and region is not None:
+            parsed = _parse_valid(text, region)
+        if parsed is None:
+            return None
+        return str(format_number(parsed, PhoneNumberFormat.E164))
 
     def country_hint(self, value: str) -> str | None:
         try:

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -8282,7 +8282,7 @@
       "plural": "Numbers"
     },
     "phone": {
-      "description": "A phone number in E.164 format. This means that phone numbers always\ninclude an international country prefix (e.g. `+38760183628`). The\ncleaning and validation functions for this try to be smart about by\naccepting a list of countries as an argument in order to add the number\nprefix.\n\nWhen adding a property of this type to an entity, any country-type properties\ndefined for the entity are considered for validation. That means that adding a\nphone number to an entity before adding a country can have a different\nvalidation outcome from doing the two operations the other way around. Always\ndefine the country first.",
+      "description": "A phone number in E.164 format, i.e. one that always carries an\ninternational dialing prefix (e.g. `+38760183628`).\n\nSource data often gives numbers in national format, without that prefix. Pass\nthe country the number is dialed in as the `format` hint to have the prefix\napplied, e.g. `entity.add(\"phone\", \"017623423980\", format=\"de\")`. A number\nthat is neither in international format nor accompanied by a hint is rejected.",
       "group": "phones",
       "label": "Phone number",
       "matchable": true,

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -8282,7 +8282,7 @@
       "plural": "Numbers"
     },
     "phone": {
-      "description": "A phone number in E.164 format. This means that phone numbers always\ninclude an international country prefix (e.g. `+38760183628`). The\ncleaning and validation functions for this try to be smart about by\naccepting a list of countries as an argument in order to add the number\nprefix.\n\nWhen adding a property of this type to an entity, any country-type properties\ndefined for the entity are considered for validation. That means that adding a\nphone number to an entity before adding a country can have a different\nvalidation outcome from doing the two operations the other way around. Always\ndefine the country first.",
+      "description": "A phone number in E.164 format, i.e. one that always carries an\ninternational dialing prefix (e.g. `+38760183628`).\n\nSource data often gives numbers in national format, without that prefix. Pass\nthe country the number is dialed in as the `format` hint to have the prefix\napplied, e.g. `entity.add(\"phone\", \"017623423980\", format=\"de\")`. A number\nthat is neither in international format nor accompanied by a hint is rejected.",
       "group": "phones",
       "label": "Phone number",
       "matchable": true,

--- a/tests/types/test_phones.py
+++ b/tests/types/test_phones.py
@@ -1,4 +1,7 @@
+import pytest
+
 from followthemoney import model
+from followthemoney.exc import InvalidData
 from followthemoney.types import registry
 
 
@@ -13,12 +16,63 @@ def test_us_number():
     assert phones.validate("banana") is False
 
 
-def test_de_number():
+def test_country_format_hint():
+    phones = registry.phone
+    assert phones.clean("017623423980") is None
+    assert phones.clean("017623423980", format="de") == "+4917623423980"
+    assert phones.clean("017623423980", format="DE") == "+4917623423980"
+    assert phones.clean("017623423980", format="deu") == "+4917623423980"
+    # A subdivision resolves to the country it dials through:
+    assert phones.clean("020 8366 1177", format="gb-eng") == "+442083661177"
+    # An international number is not affected by a hint:
+    assert phones.clean("+4917623423980", format="us") == "+4917623423980"
+    # A hint does not rescue a number that is invalid in that country:
+    assert phones.clean("017623423980", format="us") is None
+
+
+def test_validate_honours_format():
+    phones = registry.phone
+    assert phones.validate("017623423980") is False
+    assert phones.validate("017623423980", format="de") is True
+
+
+def test_invalid_format_hint():
+    phones = registry.phone
+    # Junk, and territories that have no dialing plan of their own:
+    for hint in ("banana", "xx", "eu", "zz", "suhh"):
+        with pytest.raises(InvalidData):
+            phones.clean("017623423980", format=hint)
+    # Reported even when the number would be accepted without the hint:
+    with pytest.raises(InvalidData):
+        phones.clean("+4917623423980", format="banana")
+
+
+def test_entity_add_with_format():
+    entity = model.make_entity("Person")
+    entity.add("phone", "017623423980", format="de")
+    assert entity.get("phone") == ["+4917623423980"]
+
+    # The hint stands on its own, whatever countries the entity carries:
+    other = model.make_entity("Person")
+    other.add("phone", "017623423980", format="de")
+    other.add("country", "gb")
+    assert other.get("phone") == ["+4917623423980"]
+
+
+def test_entity_countries_are_not_used():
     phones = registry.phone
     proxy = model.make_entity("Person")
     proxy.add("country", "DE")
-    assert phones.clean("017623423980") is None
-    assert phones.clean("017623423980", proxy=proxy) == "+4917623423980"
+    assert phones.clean("017623423980", proxy=proxy) is None
+    assert phones.clean("017623423980", format="de", proxy=proxy) == "+4917623423980"
+
+    # No country-type property rescues a number in national format, whichever
+    # one carries the country:
+    entity = model.make_entity("Person")
+    entity.add("country", "de")
+    entity.add("birthCountry", "de")
+    entity.add("phone", "017623423980")
+    assert entity.get("phone") == []
 
 
 def test_specificity():


### PR DESCRIPTION
Closes #333.

`PhoneType` derived the dialing region from the country properties of the entity a value was added to, via the `proxy=` argument that `unsafe_add` passes into `clean_text`. As @jlstro documented, that makes the stored value a function of entity state at `add()` time, and in the multi-country case a function of set iteration order — confirmed by varying `PYTHONHASHSEED` on 4.10.1:

```
seed 0 -> ['+491776123456']   # countries ['de','gb']
seed 1 -> ['+441776123456']   # countries ['gb','de']
```

## What changes

Numbers in national format take their country through the existing `format` hint:

```python
entity.add("phone", "017623423980", format="de")
registry.phone.clean("020 8366 1177", format="gb-eng")   # '+442083661177'
```

`format` is already documented as a type-specific hint (a `strptime` pattern for dates, an identifier format for `IdentifierType`) and is already threaded through `add`, `set`, `unsafe_add` and `clean` on both `EntityProxy` and `StatementEntity`, so this needs no new parameter anywhere.

Hints resolve through `rigour.territories`, so alpha-3 codes and subdivisions like `gb-eng` work — the latter falls back to the country it dials through. Territories with no dialing plan of their own (`eu`, `zz`, historical states like `suhh`) and unresolvable codes raise `InvalidData`. The hint is resolved *before* parsing, so a bad hint is reported even when the number happens to already be in international format.

Dropping the `validate()` override lets the base class handle it. That closes a smaller inconsistency: `validate()` has always had a `format` parameter and ignored it, so `registry.phone.validate("017623423980")` was `False` while `add()` on a DE entity stored the number. Both now take `format`, and neither looks at entity state.

## Breaking change

The entity is no longer consulted. A national-format number that used to be rescued by a country property is now rejected — exactly as it already was whenever the country happened to be added *after* the phone number.

Blast radius in the crawler fleet: 33 files under `datasets/` add a phone property, 29 of which also set a country somewhere. That's an upper bound rather than a count of affected crawlers, since numbers already in international format are unaffected either way, but those are the files to look at. There is no phone helper in `zavod/helpers/`, so each does its own thing.

I did not add a deprecation path — @pudo asked for the removal directly. Worth deciding whether zavod wants a `h.make_phone(context, value, country)` helper to land alongside this, since every crawler that breaks will need the country threaded to the `add()` call.

## Deliberately not in scope

The prefix-doubling bug from the issue is untouched and still reproduces, with an explicit hint just as much as with the old inference:

```python
registry.phone.clean("491771234567", format="de")   # '+49491771234567', is_valid_number() == True
```

`phonenumbers` reads `491771234567` as a national number in DE. Fixing it means choosing between two readings that can both be valid, which is an editorial call worth its own review rather than a rider on an API change. Happy to follow up.

## Verification

`make test` (308 passed), `make typecheck`, `make lint` all clean. New tests cover the hint (including alpha-3 and subdivision forms), the rejection cases, `validate()` honouring `format`, and that country properties no longer affect parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
