### PR TITLE
Add an entity-level `external` property to StatementEntity

### DIFF
--- a/followthemoney/statement/entity.py
+++ b/followthemoney/statement/entity.py
@@ -132,6 +132,24 @@ class StatementEntity(EntityProxy):
         return max(seen, default=None)
 
     @property
+    def external(self) -> bool:
+        """Whether every statement backing this entity is external, i.e. the whole
+        entity is a pre-verification suggestion rather than published data.
+
+        Reach for this when deciding if an entity can be treated as real: a single
+        non-external statement means some part of the entity has been verified, so
+        the entity as a whole counts as internal. An entity without any statements
+        is not external.
+        """
+        found = False
+        for stmts in self._statements.values():
+            for stmt in stmts:
+                if not stmt.external:
+                    return False
+                found = True
+        return found
+
+    @property
     def datasets(self) -> set[str]:
         datasets: set[str] = set()
         for stmt in self._iter_stmt():
@@ -212,6 +230,7 @@ class StatementEntity(EntityProxy):
         lang: str | None = None,
         original_value: str | None = None,
         origin: str | None = None,
+        external: bool = False,
     ) -> None:
         prop_name = self._prop_name(prop, quiet=quiet)
         if prop_name is None:
@@ -227,6 +246,7 @@ class StatementEntity(EntityProxy):
             lang=lang,
             original_value=original_value,
             origin=origin,
+            external=external,
         )
 
     def add(
@@ -240,6 +260,7 @@ class StatementEntity(EntityProxy):
         lang: str | None = None,
         original_value: str | None = None,
         origin: str | None = None,
+        external: bool = False,
     ) -> None:
         prop_name = self._prop_name(prop, quiet=quiet)
         if prop_name is None:
@@ -256,6 +277,7 @@ class StatementEntity(EntityProxy):
                 lang=lang,
                 original_value=original_value,
                 origin=origin,
+                external=external,
             )
         return
 
@@ -273,6 +295,7 @@ class StatementEntity(EntityProxy):
         lang: str | None = None,
         original_value: str | None = None,
         origin: str | None = None,
+        external: bool = False,
     ) -> str | None:
         """Add a statement to the entity, possibly the value."""
         if value is None or len(value) == 0:
@@ -310,6 +333,7 @@ class StatementEntity(EntityProxy):
             original_value=original_value,
             first_seen=seen,
             origin=origin,
+            external=external,
         )
         self.add_statement(stmt)
         return clean

--- a/tests/statement/test_entity.py
+++ b/tests/statement/test_entity.py
@@ -258,3 +258,63 @@ def test_entity_origin():
     sp.add_statement(stmt)
     data = sp.to_dict()
     assert data["origin"] == ["space"]
+
+
+def test_entity_external():
+    dx = Dataset.make({"name": "test", "title": "Test"})
+    empty = StatementEntity(dx, {"id": "bla", "schema": "Person"})
+    assert empty.external is False
+
+    sp = StatementEntity.from_data(dx, EXAMPLE)
+    assert sp.external is False
+
+    ext = StatementEntity(dx, {"id": "bla", "schema": "Person"})
+    ext.add("name", "John Doe", external=True)
+    ext.add("birthDate", "1976", external=True)
+    assert ext.external is True
+
+    stmts = ext.get_statements("name")
+    assert len(stmts) == 1
+    assert stmts[0].external is True
+    assert stmts[0].id != sp.get_statements("name")[0].id
+
+    # A single internal statement makes the whole entity internal again:
+    ext.add("lastName", "Doe")
+    assert ext.external is False
+    ext.pop("lastName")
+    assert ext.external is True
+
+    # The same value added both ways yields two distinct statements:
+    ext.add("name", "John Doe")
+    assert ext.external is False
+    assert len(ext.get_statements("name")) == 2
+    assert ext.get("name") == ["John Doe"]
+
+    # set() replaces the property and applies the flag:
+    ext.set("name", "John Doe", external=True)
+    assert ext.external is True
+    assert len(ext.get_statements("name")) == 1
+
+
+def test_entity_external_roundtrip():
+    dx = Dataset.make({"name": "test", "title": "Test"})
+    ext = StatementEntity(dx, {"id": "bla", "schema": "Person"})
+    ext.add("name", "John Doe", external=True)
+    ext.add("birthDate", "1976", external=True)
+
+    other = StatementEntity.from_data(dx, ext.to_statement_dict())
+    assert other.external is True
+
+    statements = list(ext._iter_stmt())
+    assert StatementEntity.from_statements(dx, statements).external is True
+
+    mixed = statements + [
+        Statement(
+            entity_id="bla",
+            prop="lastName",
+            schema="Person",
+            value="Doe",
+            dataset=dx.name,
+        )
+    ]
+    assert StatementEntity.from_statements(dx, mixed).external is False


### PR DESCRIPTION
Adds `StatementEntity.external`: an entity is external when *every* statement backing it is external, i.e. nothing about it has been through verification yet. A single non-external statement means some part of the entity is published data, so the entity as a whole counts as internal.

`Statement.external` has always been per-claim, with no entity-level equivalent — code that wanted to know "is this entity real yet?" had to write the loop itself. The one existing implementation is `has_published_substance()` in the `ann_graph_topics` analyzer over in opensanctions, which hand-rolls it (and has to know to skip `BASE_ID`).

### Notes for review

**The aggregate iterates `_statements`, not `statements`.** The synthesized `BASE_ID` checksum statement is always constructed without `external=`, so it is unconditionally `False` — a naive `all(s.external for s in entity.statements)` reports every entity as internal. `_statements` never holds `BASE_ID` statements, so it's the correct scope.

**An entity with no statements is not external.** No statements means no evidence of externality; a fresh or fully-popped entity shouldn't read as unverified.

**No caching.** Follows the recompute pattern of the other aggregates (`first_seen`, `last_seen`, `datasets`, `referents`). A cached value would need invalidation in `add_statement`, `set`, `pop`, `remove`, `merge`, *and* `from_statements` — the last of which bypasses `add_statement` entirely by assigning `_statements` directly. The property short-circuits on the first non-external statement instead.

**Deliberately not included:** no `ValueEntity` mirror, no serialization into `to_dict()` / `to_context_dict()`, no participation in `checksum`. Keeps this a runtime-derived value with no round-trip contract to maintain.

### Also: `external=` on the write API

`set()` / `add()` / `unsafe_add()` gained a trailing `external: bool = False` that flows into the constructed `Statement`, so external entities can be built through the property API rather than only from hand-constructed `Statement` objects. The parameter is positioned to match the pre-existing `zavod.Entity.unsafe_add` override, whose signature now lines up with the parent instead of extending it.

Worth knowing: `Statement.make_key()` folds `external` into the statement ID (`.ext` suffix), so the same value added internally and externally yields two distinct statements — in which case `external` correctly returns `False`. There's a test for that.

### Verification

- `make test` — 310 passed, including `test_example_entity`'s exact checksum assertions
- `make typecheck` — clean, confirms the signature extensions are LSP-clean under `--strict`
- `mypy --strict zavod/entity.py` in opensanctions — clean, downstream override still compatible

### Related

opensanctions/nomenklatura#355 — two store views mishandle the per-statement flag (`RedisView` loses it on read, `SQLView` never filters on it). This property is only trustworthy on backends that round-trip the flag correctly; LevelDB and memory stores do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
