### PR TITLE
Stop running CI twice on every pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
 name: build
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  push:
+    branches: [main]
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -11,6 +13,13 @@ permissions:
   attestations: write
   artifact-metadata: write
 
+# Supersede in-flight runs for the same ref, but only for pull requests. Tag
+# pushes must never be cancelled: the publish steps below push to PyPI, NPM,
+# Maven and GHCR in sequence, so an abort mid-run leaves a half-released version.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   python:
     runs-on: ubuntu-latest
@@ -18,8 +27,6 @@ jobs:
       matrix:
         python:
           - "3.11"
-          - "3.12"
-          - "3.13"
           - "3.14"
     steps:
       - uses: actions/checkout@v7
@@ -71,7 +78,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install build tool
         run: python -m pip install --upgrade pip build
       - name: Build wheel and sdist

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: docs
 
 on:
   push:
+    branches: [main]
+    tags: ['*']
   pull_request:
   workflow_dispatch:
 
@@ -10,9 +12,12 @@ permissions:
   pages: write
   id-token: write
 
+# Scoped per ref so PR docs builds don't queue behind each other, or behind a
+# deploy from main. The serialised "pages" group lives on the deploy job, which
+# is the only part that must not run concurrently with itself.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Build job
@@ -48,6 +53,9 @@ jobs:
   # Deployment job
   deploy:
     if: ${{ github.ref == 'refs/heads/main' }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">= 3.11"
 dependencies = [


### PR DESCRIPTION
Every CI job has been running twice on every pull request.

Both workflows triggered on unfiltered `push` **and** `pull_request`. For a branch pushed to this repo, GitHub fires both events on the same commit, so each workflow ran twice over identical code. Measured on #357: four workflow runs where there should have been two, with every check duplicated — `python (3.11–3.14)`, `java`, `nodejs`, `docker`, docs `build`, `deploy`. Over the last 100 `build.yml` runs: 59 `push` + 41 `pull_request`, so ~40% of runs were waste. Fork PRs fire `pull_request` alone, which is why this went unnoticed.

Net effect of this PR: ~22 job-runs per commit down to ~9.

### Triggers

`push` now filters to `main` and tags; `pull_request` covers branch work.

Every publish step gates on `github.event_name == 'push'` plus a `refs/tags` prefix — PyPI, NPM, Maven, GHCR, and the release attestations. Tag pushes still fire `push`, so releases are unaffected; I desk-checked all eleven gates.

One accepted behaviour change: pushing a branch with no PR open now gets no CI.

### Concurrency

`build.yml` had no `concurrency` block at all, so a fixup push left the superseded run running to completion. Added one, with `cancel-in-progress` conditional on the event:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

The condition is load-bearing. A blanket `true` would let a second tag push abort an in-flight release *between* the PyPI, NPM, Maven and GHCR uploads, leaving a half-published version. Cancelling is only safe for PR runs, which publish nothing.

`docs.yml` had the opposite problem: its workflow-level group was a single global `"pages"` with `cancel-in-progress: false`, not scoped to the ref and never cancelling — so every PR docs build queued behind every other PR docs build *and* behind main's deploys. That's a throughput problem, not just waste. The group is now per-ref, and the serialised `pages` group moved onto the `deploy` job, which is the only part that must not overlap with itself (and is already gated to `main`).

### Python matrix: 3.11 + 3.14

Dropped the interior versions. Reasoning for each retained end:

- **3.11** is the floor from `requires-python`, and because there's no `[tool.mypy]` `python_version` pin, this shard is the *only* thing type-checking against 3.11. It has to stay.
- **3.14** is the newest supported, the check name `protect-main` requires, and the interpreter the Docker image actually ships (`ubuntu:26.04`'s system python — implicit, never declared anywhere).

Nothing in the package uses 3.12+ syntax or stdlib — no PEP 695 generics, no `itertools.batched`, no `@override` — so the interior shards weren't covering a distinct code path.

I checked the `protect-main` ruleset before doing this: it requires exactly `python (3.14)` and `nodejs (24.x)`. Neither 3.12 nor 3.13 is a required context, so nothing is stranded waiting on a check that can never report.

Two loose ends tidied while in here: the `wheel` job built on 3.13, which is no longer exercised — moved to 3.14; and the classifiers stopped at 3.13 while CI had been testing 3.14 all along — added the missing one, keeping 3.12/3.13 since those state the supported range, not the tested matrix.

### Follow-ups, deliberately not in this PR

- `contrib/check_model.py`, `make default-model` and `make lint` run on every matrix shard and only need to run once. Halving the shards halves that redundancy; factoring them into their own job would change check names and interacts with the ruleset.
- `wheel`'s `attest-build-provenance` runs on PRs, minting attestations for throwaway artifacts. Gating it to tags is reasonable, but that's a supply-chain decision rather than a CI-cost one.
- `contrib/benchmarks/run.sh` lists Python 3.8–3.10, below `requires-python`. Stale, unrelated to CI.

### Verification

Both files parse and lint clean. The real check is observational — see the check list on this PR: every check should appear exactly once, from two workflow runs rather than four, with only `python (3.11)` and `python (3.14)` shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
