### PR TITLE
Replace click's deprecated stream helpers with click.open_file

### DIFF
--- a/followthemoney/cli/cli.py
+++ b/followthemoney/cli/cli.py
@@ -65,7 +65,7 @@ def sign(infile: Path, outfile: Path, signature: str | None) -> None:
 @cli.command(help="Format a stream of entities to make it readable")
 @click.option("-i", "--infile", type=InPath, default="-")
 def pretty(infile: Path) -> None:
-    stdout = click.get_binary_stream("stdout")
+    stdout = click.open_file("-", "wb")
     try:
         f = orjson.OPT_INDENT_2 | orjson.OPT_APPEND_NEWLINE
         for entity in path_entities(infile, ValueEntity):

--- a/followthemoney/cli/exports.py
+++ b/followthemoney/cli/exports.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TextIO
+from typing import TextIO, cast
 
 import click
 
@@ -14,11 +14,8 @@ from followthemoney.export.neo4j import CypherGraphExporter, Neo4JCSVExporter
 
 @contextmanager
 def text_out(path: Path) -> Generator[TextIO, None, None]:
-    if str(path) == "-":
-        yield click.get_text_stream("stdout")
-        return
-    with open(path, "w") as fh:
-        yield fh
+    with click.open_file(path, "w") as fh:
+        yield cast(TextIO, fh)
 
 
 @cli.command("export-csv", help="Export to CSV")

--- a/followthemoney/cli/util.py
+++ b/followthemoney/cli/util.py
@@ -2,7 +2,7 @@ import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, cast
 
 import click
 import orjson
@@ -45,22 +45,17 @@ def path_entities(
     cleaned: bool = True,
     max_line: int = MAX_LINE,
 ) -> Generator[E, None, None]:
-    if str(path) == "-":
-        fh = click.get_binary_stream("stdin")
-        yield from binary_entities(fh, entity_type, cleaned=cleaned, max_line=max_line)
-        return
-    with open(path, "rb") as fh:
-        yield from binary_entities(fh, entity_type, cleaned=cleaned, max_line=max_line)
+    with click.open_file(path, "rb") as fh:
+        yield from binary_entities(
+            cast(BinaryIO, fh), entity_type, cleaned=cleaned, max_line=max_line
+        )
 
 
 @contextmanager
 def path_writer(path: PathLike) -> Generator[BinaryIO, None, None]:
     """Open a file for writing binary content, or use stdout."""
-    if str(path) == "-":
-        yield click.get_binary_stream("stdout")
-        return
-    with open(path, "wb") as fh:
-        yield fh
+    with click.open_file(path, "wb") as fh:
+        yield cast(BinaryIO, fh)
 
 
 def export_stream(exporter: Exporter, path: Path) -> None:

--- a/followthemoney/statement/serialize.py
+++ b/followthemoney/statement/serialize.py
@@ -131,12 +131,8 @@ def read_statements(fh: BinaryIO, format: str) -> Generator[Statement, None, Non
 
 
 def read_path_statements(path: Path, format: str) -> Generator[Statement, None, None]:
-    if str(path) == "-":
-        fh = click.get_binary_stream("stdin")
-        yield from read_statements(fh, format=format)
-        return
-    with open(path, "rb") as fh:
-        yield from read_statements(fh, format=format)
+    with click.open_file(path, "rb") as fh:
+        yield from read_statements(cast(BinaryIO, fh), format=format)
 
 
 def get_statement_writer(fh: BinaryIO, format: str) -> "StatementWriter":


### PR DESCRIPTION
click 8.5.0 deprecated `get_binary_stream` and `get_text_stream`, moving them behind a module `__getattr__` annotated `-> object` (`click/__init__.py:76,124-142`) and scheduling removal in **click 9.0**. Two consequences on `main` today:

- `mypy --strict` fails with 5 × `"object" not callable` — this is mypy correctly reporting the `__getattr__` return type, not a click typing bug.
- Every call emits `DeprecationWarning: 'get_binary_stream' is deprecated and will be removed in Click 9.0.`

`click` is unpinned (`>= 8.0, < 9.0.0`), so CI picked 8.5.0 as soon as it was released and every new PR goes red. Pinning would only defer the removal, so this migrates instead.

## Change

`click.open_file` is the public replacement (re-exported at `click/__init__.py:73`, present since click 3.0, not deprecated) and already does what these call sites hand-rolled: it maps `"-"` to the standard stream, and wraps stdio so a context manager will not close it. Four of the five sites collapse into a single `with`:

```python
# before
if str(path) == "-":
    fh = click.get_binary_stream("stdin")
    yield from read_statements(fh, format=format)
    return
with open(path, "rb") as fh:
    yield from read_statements(fh, format=format)

# after
with click.open_file(path, "rb") as fh:
    yield from read_statements(cast(BinaryIO, fh), format=format)
```

Sites: `statement/serialize.py` (`read_path_statements`), `cli/util.py` (`path_entities`, `path_writer`), `cli/exports.py` (`text_out`), `cli/cli.py` (`pretty` — no path involved, so `open_file("-", "wb")`).

Note this is deliberately *not* a swap to `sys.stdout.buffer`: click's helpers run `_find_binary_writer(sys.stdout)` to cope with a replaced or wrapped stream, and the text variant handles Windows console streams. `open_file` keeps that machinery.

`open_file` returns `IO[Any]` regardless of mode, so the stream is cast at the boundary rather than widening the `BinaryIO`/`TextIO` annotations — those appear 37 times across the package and are the house convention, so widening would ripple through public signatures for no gain here.

## Verification

`310 passed`, `mypy --strict` clean over 76 files, `ruff check` clean.

Exercised every branch through the real CLI — dash and file, in both directions:

| invocation | exercises | result |
|---|---|---|
| `cat x.ijson \| ftm pretty -i -` | `pretty`, `path_entities` stdin | ok |
| `ftm sign -i x.ijson -o y.ijson` | `path_entities` + `path_writer`, files | ok |
| `ftm sign -i x.ijson -o -` | `path_writer` stdout | ok |
| `cat x.ijson \| ftm sign -i - -o y.ijson` | mixed | ok |
| `ftm sieve -i x.ijson -o -` | `read_path_statements` | ok |
| `ftm export-csv -i x.ijson -o dir/` | `text_out`, file | ok |
| `ftm export-cypher -i x.ijson -o -` | `text_out` stdout | ok |

And the deprecation is gone — under `-W error::DeprecationWarning`, `main` raises `DeprecationWarning: 'get_binary_stream' is deprecated` while this branch completes normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)