### PR TITLE
Add the corp.clone risk topic for impersonating companies

### DIFF
--- a/followthemoney/types/topic.py
+++ b/followthemoney/types/topic.py
@@ -45,6 +45,7 @@ class TopicType(EnumType):
         "corp.shell": _("Shell company"),
         "corp.public": _("Public listed company"),
         "corp.disqual": _("Disqualified"),
+        "corp.clone": _("Clone of real entity"),
         "gov": _("Government"),
         "gov.national": _("National government"),
         "gov.state": _("State government"),
@@ -103,6 +104,7 @@ class TopicType(EnumType):
     }
 
     RISKS: ClassVar[set[str]] = {
+        "corp.clone",
         "corp.disqual",
         "crime.boss",
         "crime.fin",

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -8427,6 +8427,7 @@
       "plural": "Topics",
       "values": {
         "asset.frozen": "Frozen asset",
+        "corp.clone": "Clone of real entity",
         "corp.disqual": "Disqualified",
         "corp.offshore": "Offshore",
         "corp.public": "Public listed company",

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -8427,6 +8427,7 @@
       "plural": "Topics",
       "values": {
         "asset.frozen": "Frozen asset",
+        "corp.clone": "Clone of real entity",
         "corp.disqual": "Disqualified",
         "corp.offshore": "Offshore",
         "corp.public": "Public listed company",

--- a/tests/types/test_topic.py
+++ b/tests/types/test_topic.py
@@ -13,3 +13,11 @@ def test_topic_country_codes():
     assert topics.validate("") is False
     assert topics.validate(None) is False
     assert "topic:role.pep" in topics.node_id("role.pep")
+
+
+def test_topic_risks():
+    topics = registry.topic
+    assert topics.validate("corp.clone") is True
+    assert "corp.clone" in topics.RISKS
+    assert "corp.public" not in topics.RISKS
+    assert topics.RISKS.issubset(topics._TOPICS)


### PR DESCRIPTION
Closes #359. Stacked on #362 (`pudo/control-schema`); only the last commit belongs to this PR.

## Summary

- Adds `corp.clone` to the `topic` enum, labelled **"Clone of real entity"** (jbothma's suggestion in #359: short enough for the website label box, and it states plainly that the tagged entity is the clone, not the impersonated firm).
- Adds `corp.clone` to `TopicType.RISKS`, so it counts as a counterparty risk like `reg.warn` and `corp.disqual`.
- The topic goes on the impersonator only, never on the business being impersonated — matching the two-entity pattern already used in `sg_mas_investor_alert` (real ↔ `UnknownLink` ↔ clone, with contact details and notes on the clone).
- Model dumps regenerated via `make default-model`.

Follow-ups outside this repo, per the issue thread: apply the topic in `sg_mas_investor_alert` (and `gb_fca_notices` once clone notices can be told apart), and review dedupe/autoresolve prompts so a clone is never merged with the real company it names.

## Test plan

- [x] New `test_topic_risks` asserts the topic validates, is in `RISKS`, and that `RISKS ⊆ _TOPICS`
- [x] `pytest` — 311 passed; `mypy --strict`, `ruff` clean
- [x] `make default-model` leaves the tree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
