### PR TITLE
Add Territory schema and designation fields on Risk

### DIFF
--- a/docs/explorer/schemata/Territory.md
+++ b/docs/explorer/schemata/Territory.md
@@ -1,0 +1,6 @@
+---
+hide:
+  - toc
+---
+
+{% include 'templates/schema.md' %}

--- a/followthemoney/schema/Risk.yaml
+++ b/followthemoney/schema/Risk.yaml
@@ -1,15 +1,17 @@
 Risk:
   label: Risk
   plural: Risks
-  description: "A risk associated with an entity."
+  description: >
+    A risk designation attached to an entity by an authority. Distinct from `Sanction`:
+    a `Risk` flags heightened exposure or scrutiny, not a legally binding restriction.
   extends:
     - Interval
   matchable: false
   featured:
     - entity
     - country
-    - reason
-    - status
+    - authority
+    - program
     - startDate
   required:
     - entity
@@ -24,6 +26,19 @@ Risk:
         label: "Risks"
       type: entity
       range: Thing
+    authority:
+      label: "Authority"
+      description: "The body issuing the designation, e.g. FATF, European Commission, FinCEN, ONDCP"
+    program:
+      label: "Program"
+      description: "The list or programme under which the designation is made"
+    programId:
+      label: "Program ID"
+      type: identifier
+      maxLength: 64
+    programUrl:
+      label: "Program URL"
+      type: url
     topics:
       label: Topics
       type: topic

--- a/followthemoney/schema/Territory.yaml
+++ b/followthemoney/schema/Territory.yaml
@@ -1,0 +1,72 @@
+Territory:
+  label: Territory
+  plural: Territories
+  description: >
+    A country, subnational division or other administrative area. Territories are
+    reference data with deterministic identifiers, not a geospatial model.
+  extends:
+    - Thing
+  matchable: false
+  featured:
+    - name
+    - territoryCode
+    - country
+    - level
+    - partOf
+  required:
+    - name
+  caption:
+    - name
+    - alias
+  properties:
+    partOf:
+      label: "Part of"
+      description: "The administrative unit this territory is part of, e.g. the country for a state, the state for a county"
+      type: entity
+      range: Territory
+      reverse:
+        name: subdivisions
+        label: "Subdivisions"
+    level:
+      label: "Level"
+      description: "Administrative level of the territory"
+      examples:
+        - country
+        - adm1
+        - adm2
+        - adm3
+        - locality
+    territoryCode:
+      # FIXME: rigour currently has over 600 political territories, but the `country` type
+      # only has ~240 (well north of UN members but not a full list of territories).
+      label: "Territory code"
+      description: "ISO 3166-1 alpha-2 code, ISO 3166-2 subdivision, or FollowTheMoney political territory code"
+      type: identifier
+      maxLength: 16
+      examples:
+        - us-de
+        - ua-cri
+        - ae-du
+    fipsCode:
+      label: "FIPS code"
+      description: "US Census / INCITS geocode for states or counties"
+      type: identifier
+      maxLength: 16
+      examples:
+        - "12"
+        - "12086"
+    zipCode:
+      label: "ZIP code"
+      description: "US postal ZIP code"
+      type: identifier
+      maxLength: 16
+      examples:
+        - "10001"
+        - "90210"
+    nutsCode:
+      label: "NUTS code"
+      description: "Eurostat NUTS region code; codes are reused across NUTS revisions, so the producer must pin the vintage"
+      type: identifier
+      maxLength: 16
+      examples:
+        - DE21

--- a/followthemoney/schema/Territory.yaml
+++ b/followthemoney/schema/Territory.yaml
@@ -6,7 +6,7 @@ Territory:
     reference data with deterministic identifiers, not a geospatial model.
   extends:
     - Thing
-  matchable: false
+  matchable: true
   featured:
     - name
     - territoryCode
@@ -65,7 +65,7 @@ Territory:
         - "90210"
     nutsCode:
       label: "NUTS code"
-      description: "Eurostat NUTS region code; codes are reused across NUTS revisions, so the producer must pin the vintage"
+      description: "Eurostat regional statistics code"
       type: identifier
       maxLength: 16
       examples:

--- a/followthemoney/types/topic.py
+++ b/followthemoney/types/topic.py
@@ -99,6 +99,7 @@ class TopicType(EnumType):
         "export.risk": _("Trade risk"),
         "invest.risk": _("Investment risk"),
         "invest.ban": _("Investment ban"),
+        "geo.risk": _("High-risk area"),
         "debarment": _("Debarred"),
         "poi": _("Person of interest"),
     }
@@ -118,6 +119,7 @@ class TopicType(EnumType):
         "export.control",
         "export.control.linked",
         "export.risk",
+        "geo.risk",
         "invest.risk",
         "invest.ban",
         "poi",

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -6319,20 +6319,28 @@
         "reason",
         "status"
       ],
-      "description": "A risk associated with an entity.",
+      "description": "A risk designation attached to an entity by an authority. Distinct from `Sanction`: a `Risk` flags heightened exposure or scrutiny, not a legally binding restriction.\n",
       "extends": [
         "Interval"
       ],
       "featured": [
         "entity",
         "country",
-        "reason",
-        "status",
+        "authority",
+        "program",
         "startDate"
       ],
       "label": "Risk",
       "plural": "Risks",
       "properties": {
+        "authority": {
+          "description": "The body issuing the designation, e.g. FATF, European Commission, FinCEN, ONDCP",
+          "label": "Authority",
+          "maxLength": 1024,
+          "name": "authority",
+          "qname": "Risk:authority",
+          "type": "string"
+        },
         "country": {
           "label": "Country",
           "matchable": true,
@@ -6365,6 +6373,30 @@
           "name": "listingDate",
           "qname": "Risk:listingDate",
           "type": "date"
+        },
+        "program": {
+          "description": "The list or programme under which the designation is made",
+          "label": "Program",
+          "maxLength": 1024,
+          "name": "program",
+          "qname": "Risk:program",
+          "type": "string"
+        },
+        "programId": {
+          "label": "Program ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "programId",
+          "qname": "Risk:programId",
+          "type": "identifier"
+        },
+        "programUrl": {
+          "label": "Program URL",
+          "matchable": true,
+          "maxLength": 4096,
+          "name": "programUrl",
+          "qname": "Risk:programUrl",
+          "type": "url"
         },
         "reason": {
           "label": "Reason",
@@ -6944,6 +6976,123 @@
           "date"
         ]
       }
+    },
+    "Territory": {
+      "caption": [
+        "name",
+        "alias"
+      ],
+      "description": "A country, subnational division or other administrative area. Territories are reference data with deterministic identifiers, not a geospatial model.\n",
+      "extends": [
+        "Thing"
+      ],
+      "featured": [
+        "name",
+        "territoryCode",
+        "country",
+        "level",
+        "partOf"
+      ],
+      "label": "Territory",
+      "plural": "Territories",
+      "properties": {
+        "fipsCode": {
+          "description": "US Census / INCITS geocode for states or counties",
+          "examples": [
+            "12",
+            "12086"
+          ],
+          "label": "FIPS code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "fipsCode",
+          "qname": "Territory:fipsCode",
+          "type": "identifier"
+        },
+        "level": {
+          "description": "Administrative level of the territory",
+          "examples": [
+            "country",
+            "adm1",
+            "adm2",
+            "adm3",
+            "locality"
+          ],
+          "label": "Level",
+          "maxLength": 1024,
+          "name": "level",
+          "qname": "Territory:level",
+          "type": "string"
+        },
+        "nutsCode": {
+          "description": "Eurostat NUTS region code; codes are reused across NUTS revisions, so the producer must pin the vintage",
+          "examples": [
+            "DE21"
+          ],
+          "label": "NUTS code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "nutsCode",
+          "qname": "Territory:nutsCode",
+          "type": "identifier"
+        },
+        "partOf": {
+          "description": "The administrative unit this territory is part of, e.g. the country for a state, the state for a county",
+          "label": "Part of",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "partOf",
+          "qname": "Territory:partOf",
+          "range": "Territory",
+          "reverse": "subdivisions",
+          "type": "entity"
+        },
+        "subdivisions": {
+          "label": "Subdivisions",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "subdivisions",
+          "qname": "Territory:subdivisions",
+          "range": "Territory",
+          "reverse": "partOf",
+          "stub": true,
+          "type": "entity"
+        },
+        "territoryCode": {
+          "description": "ISO 3166-1 alpha-2 code, ISO 3166-2 subdivision, or FollowTheMoney political territory code",
+          "examples": [
+            "us-de",
+            "ua-cri",
+            "ae-du"
+          ],
+          "label": "Territory code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "territoryCode",
+          "qname": "Territory:territoryCode",
+          "type": "identifier"
+        },
+        "zipCode": {
+          "description": "US postal ZIP code",
+          "examples": [
+            "10001",
+            "90210"
+          ],
+          "label": "ZIP code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "zipCode",
+          "qname": "Territory:zipCode",
+          "type": "identifier"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "Territory",
+        "Thing"
+      ]
     },
     "Thing": {
       "abstract": true,
@@ -8453,6 +8602,7 @@
         "fin.bank": "Bank",
         "fin.fund": "Fund",
         "forced.labor": "Forced labor",
+        "geo.risk": "High-risk area",
         "gov": "Government",
         "gov.admin": "Civil service",
         "gov.executive": "Executive branch of government",

--- a/java/src/main/resources/defaultModel.json
+++ b/java/src/main/resources/defaultModel.json
@@ -6994,6 +6994,7 @@
         "partOf"
       ],
       "label": "Territory",
+      "matchable": true,
       "plural": "Territories",
       "properties": {
         "fipsCode": {
@@ -7025,7 +7026,7 @@
           "type": "string"
         },
         "nutsCode": {
-          "description": "Eurostat NUTS region code; codes are reused across NUTS revisions, so the producer must pin the vintage",
+          "description": "Eurostat regional statistics code",
           "examples": [
             "DE21"
           ],

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -6319,20 +6319,28 @@
         "reason",
         "status"
       ],
-      "description": "A risk associated with an entity.",
+      "description": "A risk designation attached to an entity by an authority. Distinct from `Sanction`: a `Risk` flags heightened exposure or scrutiny, not a legally binding restriction.\n",
       "extends": [
         "Interval"
       ],
       "featured": [
         "entity",
         "country",
-        "reason",
-        "status",
+        "authority",
+        "program",
         "startDate"
       ],
       "label": "Risk",
       "plural": "Risks",
       "properties": {
+        "authority": {
+          "description": "The body issuing the designation, e.g. FATF, European Commission, FinCEN, ONDCP",
+          "label": "Authority",
+          "maxLength": 1024,
+          "name": "authority",
+          "qname": "Risk:authority",
+          "type": "string"
+        },
         "country": {
           "label": "Country",
           "matchable": true,
@@ -6365,6 +6373,30 @@
           "name": "listingDate",
           "qname": "Risk:listingDate",
           "type": "date"
+        },
+        "program": {
+          "description": "The list or programme under which the designation is made",
+          "label": "Program",
+          "maxLength": 1024,
+          "name": "program",
+          "qname": "Risk:program",
+          "type": "string"
+        },
+        "programId": {
+          "label": "Program ID",
+          "matchable": true,
+          "maxLength": 64,
+          "name": "programId",
+          "qname": "Risk:programId",
+          "type": "identifier"
+        },
+        "programUrl": {
+          "label": "Program URL",
+          "matchable": true,
+          "maxLength": 4096,
+          "name": "programUrl",
+          "qname": "Risk:programUrl",
+          "type": "url"
         },
         "reason": {
           "label": "Reason",
@@ -6944,6 +6976,123 @@
           "date"
         ]
       }
+    },
+    "Territory": {
+      "caption": [
+        "name",
+        "alias"
+      ],
+      "description": "A country, subnational division or other administrative area. Territories are reference data with deterministic identifiers, not a geospatial model.\n",
+      "extends": [
+        "Thing"
+      ],
+      "featured": [
+        "name",
+        "territoryCode",
+        "country",
+        "level",
+        "partOf"
+      ],
+      "label": "Territory",
+      "plural": "Territories",
+      "properties": {
+        "fipsCode": {
+          "description": "US Census / INCITS geocode for states or counties",
+          "examples": [
+            "12",
+            "12086"
+          ],
+          "label": "FIPS code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "fipsCode",
+          "qname": "Territory:fipsCode",
+          "type": "identifier"
+        },
+        "level": {
+          "description": "Administrative level of the territory",
+          "examples": [
+            "country",
+            "adm1",
+            "adm2",
+            "adm3",
+            "locality"
+          ],
+          "label": "Level",
+          "maxLength": 1024,
+          "name": "level",
+          "qname": "Territory:level",
+          "type": "string"
+        },
+        "nutsCode": {
+          "description": "Eurostat NUTS region code; codes are reused across NUTS revisions, so the producer must pin the vintage",
+          "examples": [
+            "DE21"
+          ],
+          "label": "NUTS code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "nutsCode",
+          "qname": "Territory:nutsCode",
+          "type": "identifier"
+        },
+        "partOf": {
+          "description": "The administrative unit this territory is part of, e.g. the country for a state, the state for a county",
+          "label": "Part of",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "partOf",
+          "qname": "Territory:partOf",
+          "range": "Territory",
+          "reverse": "subdivisions",
+          "type": "entity"
+        },
+        "subdivisions": {
+          "label": "Subdivisions",
+          "matchable": true,
+          "maxLength": 200,
+          "name": "subdivisions",
+          "qname": "Territory:subdivisions",
+          "range": "Territory",
+          "reverse": "partOf",
+          "stub": true,
+          "type": "entity"
+        },
+        "territoryCode": {
+          "description": "ISO 3166-1 alpha-2 code, ISO 3166-2 subdivision, or FollowTheMoney political territory code",
+          "examples": [
+            "us-de",
+            "ua-cri",
+            "ae-du"
+          ],
+          "label": "Territory code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "territoryCode",
+          "qname": "Territory:territoryCode",
+          "type": "identifier"
+        },
+        "zipCode": {
+          "description": "US postal ZIP code",
+          "examples": [
+            "10001",
+            "90210"
+          ],
+          "label": "ZIP code",
+          "matchable": true,
+          "maxLength": 16,
+          "name": "zipCode",
+          "qname": "Territory:zipCode",
+          "type": "identifier"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "schemata": [
+        "Territory",
+        "Thing"
+      ]
     },
     "Thing": {
       "abstract": true,
@@ -8453,6 +8602,7 @@
         "fin.bank": "Bank",
         "fin.fund": "Fund",
         "forced.labor": "Forced labor",
+        "geo.risk": "High-risk area",
         "gov": "Government",
         "gov.admin": "Civil service",
         "gov.executive": "Executive branch of government",

--- a/js/src/defaultModel.json
+++ b/js/src/defaultModel.json
@@ -6994,6 +6994,7 @@
         "partOf"
       ],
       "label": "Territory",
+      "matchable": true,
       "plural": "Territories",
       "properties": {
         "fipsCode": {
@@ -7025,7 +7026,7 @@
           "type": "string"
         },
         "nutsCode": {
-          "description": "Eurostat NUTS region code; codes are reused across NUTS revisions, so the producer must pin the vintage",
+          "description": "Eurostat regional statistics code",
           "examples": [
             "DE21"
           ],

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -183,8 +183,8 @@ def test_territory_schema():
     thing = model.schemata["Thing"]
     territory = model.schemata["Territory"]
     assert territory.is_a(thing)
-    assert territory.matchable is False
-    assert territory not in model.matchable_schemata()
+    assert territory.matchable is True
+    assert territory in model.matchable_schemata()
 
     part_of = territory.get("partOf")
     assert part_of is not None, part_of

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -179,6 +179,50 @@ def test_risk_source_property():
     assert "riskLinked" not in thing.properties
 
 
+def test_territory_schema():
+    thing = model.schemata["Thing"]
+    territory = model.schemata["Territory"]
+    assert territory.is_a(thing)
+    assert territory.matchable is False
+    assert territory not in model.matchable_schemata()
+
+    part_of = territory.get("partOf")
+    assert part_of is not None, part_of
+    assert part_of.stub is False, part_of
+    assert part_of.range == territory, part_of
+    assert part_of.reverse is not None
+    rev = part_of.reverse
+    assert rev.name == "subdivisions", rev
+    assert rev.range == territory, rev
+    assert rev.stub is True, rev
+    assert territory.get("subdivisions") == rev
+
+    for name in ("territoryCode", "fipsCode", "nutsCode"):
+        prop = territory.get(name)
+        assert prop is not None, name
+        assert prop.type == registry.identifier, prop
+
+    for schema_name in ("Risk", "Sanction"):
+        entity_prop = model.schemata[schema_name].get("entity")
+        assert entity_prop is not None
+        assert entity_prop.range is not None
+        assert territory.is_a(entity_prop.range), (schema_name, entity_prop.range)
+
+
+def test_risk_designation_properties():
+    risk = model.schemata["Risk"]
+    for name in ("authority", "program"):
+        prop = risk.get(name)
+        assert prop is not None, name
+        assert prop.type == registry.string, prop
+    program_id = risk.get("programId")
+    assert program_id is not None
+    assert program_id.type == registry.identifier, program_id
+    program_url = risk.get("programUrl")
+    assert program_url is not None
+    assert program_url.type == registry.url, program_url
+
+
 def test_matchable():
     le = model.schemata["LegalEntity"]
     company = model.schemata["Company"]

--- a/tests/types/test_topic.py
+++ b/tests/types/test_topic.py
@@ -21,3 +21,10 @@ def test_topic_risks():
     assert "corp.clone" in topics.RISKS
     assert "corp.public" not in topics.RISKS
     assert topics.RISKS.issubset(topics._TOPICS)
+
+
+def test_topic_geo_risk():
+    topics = registry.topic
+    assert topics.clean("geo.risk") == "geo.risk"
+    assert "geo.risk" in topics.names
+    assert "geo.risk" in topics.RISKS


### PR DESCRIPTION
## Summary

Adds a minimal **`Territory`** schema so that designations targeting a whole place have a proper subject entity, and extends **`Risk`** so it can carry those designations. This is the first increment of the territorial-designations work: enough for country-level lists (FATF, EU high-risk third countries, FinCEN 311) and US subnational designations (HIDTA/HIFCA counties, FinCEN GTOs). It is deliberately not a full political-geography model.

### `Territory` (new, extends `Thing`, `matchable: true`)

- `partOf` → `Territory`, reverse `subdivisions`: single-property hierarchy without an intermediate object. Named distinctly from `Document.parent`, which Aleph treats as the document tree.
- `level`: free string with examples (`country`, `adm1`, `adm2`, `adm3`, `locality`).
- `territoryCode`: ISO 3166-1 / 3166-2 or FollowTheMoney political territory code (`us-de`, `ua-cri`, `ae-du`).
- `fipsCode`: US Census / INCITS state and county geocodes.
- `zipCode`: US postal ZIP code.
- `nutsCode`: Eurostat regional statistics code.
- Names, aliases, `country`, `wikidataId`, `topics` come from `Thing`.

### `Risk`

- New `authority`, `program`, `programId`, `programUrl`, mirroring `Sanction`.
- Featured properties and description updated so `Risk` reads as the non-sanction designation interval (a FATF grey-listing is not a sanction).

### Topics

- New `geo.risk` ("High-risk area"), included in `TopicType.RISKS`.

### Deliberately left out

A `territory` property type for `LegalEntity:jurisdiction`, typed parent edges (claimed by, de facto), a jurisdiction flag, inception/dissolution dates, GeoNames IDs and `geo.*` sub-topics. These get added when a dataset needs them.

Closes #337
Refs opensanctions/opensanctions#5587

## Test plan

- [x] `pytest tests` (317 passed), `mypy --strict`, `ruff check`
- [x] New tests: Territory schema shape, self-range and reverse stub, identifier types, `Risk`/`Sanction` `entity` range accepts Territory, Risk designation properties, `geo.risk` topic
- [x] `make default-model` regenerated JS/Java models
- [x] Smoke test: Delaware `Territory` with `partOf` → US territory and a FinCEN GTO `Risk` attached, both validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
