### PR TITLE
fix(number): infer the decimal separator, and read an exponent

### DIFF
--- a/followthemoney/types/number.py
+++ b/followthemoney/types/number.py
@@ -17,11 +17,13 @@ def _number_pattern(decimal: str, separator: str) -> re.Pattern[str]:
     grp = rf"[{re.escape(separator)}\s]"
     # Either grouped digits (western 3s, indian 2/3s) or a plain run of digits.
     integer = rf"(?:\d{{1,3}}(?:{grp}\d{{2,3}})+|\d+)"
-    number = rf"[+-]?\s?{integer}(?:{dec}\d+)?"
+    exponent = r"(?:[eE][+-]?\d+)?"
+    number = rf"[+-]?\s?{integer}(?:{dec}\d+)?{exponent}"
     # A unit is digit-free: any digit after the number may belong to a second,
-    # glued-on number (a compact range, scientific notation, or a repeated
-    # decimal/grouping char), which then fails the end-anchored match rather
-    # than being mistaken for a unit (see issue #331).
+    # glued-on number (a compact range, or a repeated decimal/grouping char),
+    # which then fails the end-anchored match rather than being mistaken for a
+    # unit (see issue #331). An exponent is part of the number, not a second
+    # one, so it is matched above and `1e6` is a million.
     unit = r"[^\s\d]+"
     pattern = rf"^\s*(?P<number>{number})\s*(?P<unit>{unit})?\s*$"
     return re.compile(pattern, re.UNICODE)
@@ -71,7 +73,16 @@ class NumberType(PropertyType):
         European decimal comma under the default separator) are rejected rather
         than silently coerced into a structurally different value (see issue #331).
         """
-        match = _number_pattern(decimal, separator).match(value.strip())
+        text = value.strip()
+        match = _number_pattern(decimal, separator).match(text)
+        if match is None and decimal in text and separator in text:
+            # No convention mixes grouping characters, so a value the given
+            # locale cannot read and that holds both is the other one, with
+            # the rightmost as the decimal (issue #340). Second, because a
+            # unit is part of the string: `1.5 m,s` carries a comma that is not.
+            if text.rindex(separator) > text.rindex(decimal):
+                decimal, separator = separator, decimal
+                match = _number_pattern(decimal, separator).match(text)
         if match is None:
             return None, None
         unit = match.group("unit")

--- a/tests/types/test_number.py
+++ b/tests/types/test_number.py
@@ -84,11 +84,11 @@ def test_parse_numbers_rejects_digit_unit():
     # fully match, taking a leading number and a trailing "unit" that starts
     # with a non-digit but carries digits (e.g. "1.234" + ".567"). Such a unit
     # is really a second, glued-on number — a compact range, a repeated
-    # decimal/grouping char, scientific notation, or an expression — so we
-    # reject rather than return the head with a garbage unit.
+    # decimal/grouping char, or an expression — so we reject rather than
+    # return the head with a garbage unit. An exponent belongs to the number,
+    # and the scientific-notation test covers it.
     assert numbers.parse("1.234.567") == (None, None)  # -> would be ("1.234", ".567")
     assert numbers.parse("1,5") == (None, None)  # -> would be ("1", ",5")
-    assert numbers.parse("1e6") == (None, None)  # -> would be ("1", "e6")
     assert numbers.parse("5-10") == (None, None)  # compact range
     assert numbers.parse("10-20kg") == (None, None)  # compact range with unit
     assert numbers.parse("3x4") == (None, None)
@@ -123,3 +123,55 @@ def test_format_numbers():
     assert numbers.caption("-100000.234tonnes") == "-100,000.23 tonnes"
     assert numbers.caption("banana") == "banana"
     assert numbers.caption("1,00,000") == "100,000"
+
+
+def test_parse_numbers_infers_separator_from_both():
+    # Issue #340.1: no convention mixes grouping characters, so a value holding
+    # both reads one way, with the rightmost as the decimal. Nothing in the
+    # codebase passes the decimal/separator arguments, so it is the only route.
+    assert numbers.parse("1.000,00") == ("1000.00", None)
+    assert numbers.parse("1.234.567,89") == ("1234567.89", None)
+    assert numbers.parse("1.000,000") == ("1000.000", None)
+    assert numbers.to_number("1.234.567,89") == 1234567.89
+
+    # In western order the rightmost is the decimal too.
+    assert numbers.parse("1,234,567.89") == ("1234567.89", None)
+
+    # A unit comes back with the inferred number.
+    assert numbers.parse("1.234,56 kg") == ("1234.56", "kg")
+
+    # One separator alone stays ambiguous: "1,000" is a thousand under the
+    # default grouping, and under lakh grouping two digits after it are not a
+    # decimal either.
+    assert numbers.parse("1,000") == ("1000", None)
+    assert numbers.parse("1.000") == ("1.000", None)
+    assert numbers.parse("12,34") == ("1234", None)
+
+    # An explicit locale that disagrees with the inference is honoured,
+    # because the inference only fires when both characters are present.
+    assert numbers.parse("1,5", decimal=",", separator=".") == ("1.5", None)
+
+    # A unit is part of the value and a grouping character inside one is no
+    # locale signal, so the inference runs only where the given locale reads
+    # nothing.
+    assert numbers.parse("1.5 m,s") == ("1.5", "m,s")
+    assert numbers.parse("10.5kg,m") == ("10.5", "kg,m")
+    assert numbers.parse("1,5m.s", decimal=",", separator=".") == ("1.5", "m.s")
+
+
+def test_parse_numbers_scientific_notation():
+    # Issue #340.2: an exponent is unambiguous in every locale, so it belongs
+    # to the number and not to the unit.
+    assert numbers.parse("1e6") == ("1e6", None)
+    assert numbers.to_number("1e6") == 1000000.0
+    assert numbers.parse("1E5") == ("1E5", None)
+    assert numbers.parse("1.5e-3") == ("1.5e-3", None)
+    assert numbers.to_number("1.5e-3") == 0.0015
+    assert numbers.parse("2.5E+4") == ("2.5E+4", None)
+    assert numbers.parse("1e6 kg") == ("1e6", "kg")
+
+    # A unit beginning with 'e' is not an exponent, and an 'e' with no digits
+    # after it is not one either.
+    assert numbers.parse("5eV") == ("5", "eV")
+    assert numbers.parse("5 eV") == ("5", "eV")
+    assert numbers.parse("1e") == ("1", "e")


### PR DESCRIPTION
Closes the first two parts of #340.

`NumberType.parse` takes `decimal` and `separator` arguments and nothing in the codebase passes them, so European formatting is unreachable: `1.000,00` returns `(None, None)`. No convention mixes grouping characters, so where a value holds both and the given locale cannot read it, the rightmost is the decimal. `1.234.567,89` now parses to `1234567.89`.

The inference runs only after the given locale has failed. Reading it first took values away, because a unit is part of the string and `1.5 m,s` carries a comma nobody meant as a separator; there is a test for each of those three.

The second part is the exponent. A unit is digit-free by #331, so `1e6` matched with `1` as the number and `e6` as the unit. An exponent is unambiguous in every locale, so it moves into the number: `1e6` is a million, `1.5e-3` is 0.0015, and `5eV` and `1e` still come back as a number with a unit.

That takes one assertion out of `test_parse_numbers_rejects_digit_unit`, `numbers.parse("1e6") == (None, None)`, which is what #340 asks for.

Both changes only widen. Importing the module from two worktrees and comparing `parse` over 83 values across three locales, 249 pairs, 33 answers change and every one of them is `(None, None)` becoming a value. 319 tests pass, `mypy --strict` is clean over 76 files and so is `ruff`.

Part three of the issue, threading `decimal` and `separator` through the callers or hanging them on the class, is a design call and is not here.
